### PR TITLE
docs: CPLYTM-1089 adding README's for microservices

### DIFF
--- a/compass/README.md
+++ b/compass/README.md
@@ -4,7 +4,7 @@
 
 The `compass` API provides compliance context enrichment for OpenTelemetry log records. 
 
-## Compatibility
+## Usage
 
 The `compass` API can be deployed as an independent API, enabling it to be called in any OpenTelemetry-based log enrichment pipeline.
 
@@ -17,11 +17,4 @@ The `compass` API can be deployed as an independent API, enabling it to be calle
 3. **Compass API Response:** `{compliance: {catalog: "NIST-800-53", control: "AC-2"}, status: {title: "Fail"}}`
 4. **Enriched Log:** `{policy.id: "github_branch_protection", compliance.status: "Fail", compliance.control: "AC-2"}`
 
-## Writing tests for `compass`
-
-> **Disclaimer:** As development progresses, additional tests will be added to increase the coverage.
-
-To write effective unit-tests for the `compass` API follow these guidelines:
-
-1. Unit-tests are located in the `compass` directory.
-2. Tests should follow the [go testing style](https://go.dev/doc/tutorial/add-a-test). Review existing tests for readability.
+> Review guidelines for writing tests in the [DEVELOPMENT.md](https://github.com/complytime/complybeacon/blob/main/docs/DEVELOPMENT.md).

--- a/proofwatch/README.md
+++ b/proofwatch/README.md
@@ -4,20 +4,42 @@
 
 Proofwatch captures, normalizes, and emits formatted compliance-data logs using the OpenTelemetry format (OTLP).
 
-## Compatibility 
+## Usage 
 
-Proofwatch is a distinctive microservice that can be used any standard OpenTelemetry Collector to receive and process compliance-data logs.
+Proofwatch is an OpenTelemetry instrumentation library that enable applications to log compliance evidence and policy evaluation events using OpenTelemetry's structured logging format.
 
 > **Note:** Proofwatch is commonly used with the [`Beacon`](https://github.com/complytime/complybeacon/blob/ba4106b36dd25b08c15d134650843fb4bffc4e0e/beacon-distro) Collector which leverages [`truthbeam`](https://github.com/complytime/complybeacon/blob/953910cf8a7b1c8c44b8e21630bbb112461d30f0/truthbeam) and [`compass`](https://github.com/complytime/complybeacon/blob/ba4106b36dd25b08c15d134650843fb4bffc4e0e/compass) for processing, enrichment, and export of logs.
 
-## Writing unit-tests for `proofwatch`
+### Example Code Snippet
 
-> **Disclaimer:** As development progresses, additional tests will be added to increase the coverage.
+```go
+import (
+    "context"
+    "log"
+    
+    "go.opentelemetry.io/otel/log"
+    "github.com/complytime/complybeacon/proofwatch"
+)
 
-To write effective unit-tests for the `proofwatch` instrumentation kit follow these guidelines:
+// Create a new ProofWatch instance
+pw, err := proofwatch.NewProofWatch()
+if err != nil {
+    log.Fatal(err)
+}
 
-1. Unit-tests are located in the `proofwatch` directory. 
-2. Prioritize maintainability of the unit-tests. When appropriate, use the [attributes.go](https://github.com/complytime/complybeacon/blob/ba4106b36dd25b08c15d134650843fb4bffc4e0e/proofwatch/attributes.go) _instead_ of hard-coded strings in the unit-tests.
-3. Tests should follow the [go testing style](https://go.dev/doc/tutorial/add-a-test). Review existing tests for readability.
+// Create evidence (example with GemaraEvidence)
+evidence := proofwatch.GemaraEvidence{
+    // ... populate evidence fields
+}
 
-> Example: [gemara.go](https://github.com/complytime/complybeacon/blob/ba4106b36dd25b08c15d134650843fb4bffc4e0e/proofwatch/gemara.go) is properly tested by the [gemara_test.go](https://github.com/complytime/complybeacon/blob/ba4106b36dd25b08c15d134650843fb4bffc4e0e/proofwatch/gemara_test.go).
+// Log evidence with default severity
+err = pw.Log(ctx, evidence)
+if err != nil {
+    return fmt.Errorf("error logging evidence: %w", err)
+}
+
+// Or log with specific severity
+err = pw.LogWithSeverity(ctx, evidence, olog.SeverityWarn)
+```
+
+> Review guidelines for writing tests in the [DEVELOPMENT.md](https://github.com/complytime/complybeacon/blob/main/docs/DEVELOPMENT.md).

--- a/truthbeam/README.md
+++ b/truthbeam/README.md
@@ -2,30 +2,66 @@
 
 ## Overview
 
-The `truthbeam` custom OpenTelemetry Processor is part of the OpenTelemetry Pipeline. The `truthbeam` processor will ingest check normalized logs for required attributes and formulate an enrichment request to query the `compass` API. The logs will be enriched with compliance context attributes from the `compass` API and `truthbeam` will add those attributes to the original log record.  
+The `truthbeam` custom OpenTelemetry Processor is a component in the OpenTelemetry Pipeline that ingests and validates normalized logs for required attributes. It then formulates an enrichment request to query the `compass` API. Once enriched with compliance-context attributes from `compass`, `truthbeam` adds these new attributes back to the original log record.
 
-## Compatibility
+## Usage
 
 The `truthbeam` processor can be integrated into any OpenTelemetry Collector distribution.
 
 > **Note:** The `truthbeam` processor **gracefully** handles API failures to ensure log records won't be discarded.
 
-## Writing tests for `truthbeam`
+### Example Code Snippet **Log -> Enrichment Request -> Enrichment Response -> Enriched Log**
 
-> **Disclaimer:** As development progresses, additional tests will be added to increase the coverage.
+**Log Record:** The log record from the `sameple_logs.json` is an example of a log record that would be ingested by the `truthbeam` processor. 
 
-To write effective unit-tests for the `truthbeam` custom OpenTelemetry Processor follow these guidelines:
+```json
+ "attributes": [
+                {
+                  "key": "policy.id",
+                  "value": {
+                    "stringValue": "github_branch_protection"
+                  }
+                },
+                {
+                  "key": "policy.evaluation.status",
+                  "value": {
+                    "stringValue": "fail"
+                  }
+                },
+```
 
-1. Unit-tests are located in the `truthbeam` directory. 
-2. Prioritize maintainability of the unit-tests. When appropriate, use the [attributes.go](https://github.com/complytime/complybeacon/blob/472aafba724b709ab3c9087c401275ebeb171943/truthbeam/internal/client/attributes.go) _instead_ of hard-coded strings in the unit-tests. 
-3. Tests should follow the [go testing style](https://go.dev/doc/tutorial/add-a-test). Review existing tests for readability.
+**Enrichment Request:** The enrichment request is formed by the `truthbeam` processor based on the log record from the policy-engine source.
 
-### Existing test files
+```json
+{
+  "evidence": {
+    "timestamp": "2025-01-05T12:30:00Z",
+    "source": "conforma",
+    "policyId": "github_branch_protection",
+    "decision": "fail",
+    "action": "audit",
+    "categoryId": 6,
+    "classId": 6007
+  }
+}
+```
 
-`config_test.go`: Uses table-driven tests to validate configuration validation and default values for the truthbeam processor.
+**Enrichment Response:** The enrichment response is the response from the `compass` API.
 
-`factory_test.go`: Tests the processor factory lifecycle including creation, configuration validation, and proper component initialization.
+```json
+{
+  "compliance": {
+    "catalog": "NIST-800-53",
+    "control": "AC-2"
+  },
+  "status": {
+    "title": "Fail"
+  }
+}
+```
 
-`processor_test.go`: Validates the core processor functionality including log processing, enrichment request formation, and response handling.
+**Enriched Log:** The `truthbeam` processor adds the enrichment response as attributes to the log record.
 
-`apply_test.go`: Tests the attribute application logic for enriching log records with compliance data from the compass API.
+## Development
+
+> Review guidelines for writing tests in the [DEVELOPMENT.md](https://github.com/complytime/complybeacon/blob/main/docs/DEVELOPMENT.md).

--- a/truthbeam/config_test.go
+++ b/truthbeam/config_test.go
@@ -7,6 +7,9 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 )
 
+// The config tests are table-driven tests to validate configuration validation
+//and default values for the truthbeam processor.
+
 // TestConfigValidate tests the Validate method of the Config struct
 func TestConfigValidate(t *testing.T) {
 	tests := []struct {

--- a/truthbeam/factory_test.go
+++ b/truthbeam/factory_test.go
@@ -10,6 +10,9 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 )
 
+// The factory tests validate processor factory lifecycle including creation,
+// configuration validation, and proper component initialization.
+
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	config := factory.CreateDefaultConfig()

--- a/truthbeam/internal/client/apply_test.go
+++ b/truthbeam/internal/client/apply_test.go
@@ -14,6 +14,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
+// The apply tests validate attribute application logic for enrichment of log records
+// with compliance data from the compass API.
+
 // TestApplyAttributes tests the ApplyAttributes functionality with a valid response.
 func TestApplyAttributes(t *testing.T) {
 	// Create a mock HTTP server

--- a/truthbeam/processor_test.go
+++ b/truthbeam/processor_test.go
@@ -21,6 +21,9 @@ import (
 	"github.com/complytime/complybeacon/truthbeam/internal/client"
 )
 
+// The processor tests validate the core processor functionality including log processing,
+// enrichment request formation, and response handling.
+
 func TestNewTruthBeamProcessor(t *testing.T) {
 	cfg := &Config{
 		ClientConfig: confighttp.NewDefaultClientConfig(),


### PR DESCRIPTION
# Description

This PR updates the `truthbeam`, `compass`, and `proofwatch` packages to include separate `README.md` files to describe the functionality of each microservice and the existing test implementation. This documentation is very lightweight and emphasizes readability, maintainability, and the compatibility of the components with existing tools.

## Review Hints

Review alongside the `DESIGN.md` for accuracy checks.