### PR TITLE
feat: CPLYTM-1088 Enforce coverage threshold

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -74,27 +74,28 @@ jobs:
             (cd "$m" && rm -f coverage.out)
           done
           rm -f coverage.out
-
-          # Create workspace dynamically
-          echo "Setting up go.work..."
-          rm -f go.work go.work.sum  # Remove if exists
-          go work init
-          for m in $modules; do
-            echo "Adding module to workspace: $m"
-            go work use ./$m
-          done
-          go work sync
-          echo "Workspace created:"
-          cat go.work
           
           # Test each module
           for m in $modules; do
             echo "--- generating coverage for module: $m"
-            go test -v -covermode=atomic -coverprofile="$m/coverage.out" ./$m/...
-            go tool cover -func="$m/coverage.out" | tail -n1 || true
+            (
+              cd "$m"
+              go test -v -covermode=atomic -coverprofile=coverage.out ./...
+              go tool cover -func=coverage.out | tail -n1 || true
+            )
           done
+          
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+          # Create workspace for merged coverage analysis
+          echo "Setting up go.work for coverage analysis..."
+          rm -f go.work go.work.sum
+          go work init
+          for m in $modules; do
+            go work use ./$m
+          done
+          go work sync
+          
           # Merge coverage files
           go install github.com/wadey/gocovmerge@latest
           
@@ -109,7 +110,6 @@ jobs:
             gocovmerge "${covs[@]}" > coverage.out
             echo "Coverage file: coverage.out"
 
-<<<<<<< HEAD
             echo ""
             echo "=== Total Coverage (all files) ==="
             go tool cover -func=coverage.out | tail -n1
@@ -122,61 +122,18 @@ jobs:
             # Extract coverage percentage
             pct=$(go tool cover -func=coverage-filtered.out | tail -n1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
           
-=======
-            # Calculate coverage from merged file (including ALL code)
-            # Format: path:lines num_statements execution_count
-            pct_all=$(awk '
-              /^mode:/ { next }
-              {
-                statements += $2
-                if ($3 > 0) covered += $2
-              }
-              END {
-                if (statements > 0) {
-                  coverage = 100.0 * covered / statements
-                  printf "%.1f", coverage
-                } else {
-                  print "0.0"
-                }
-              }
-            ' coverage.out)
-            echo "Total coverage (all code): $pct_all%"
-
-            # Calculate coverage with exclusions (matching SonarCloud)
-            # Exclude: *_test.go, cmd/, *.gen.go files
-            pct=$(awk '
-              /^mode:/ { next }
-              # Skip lines matching exclusion patterns
-              /_test\.go:/ { next }
-              /\/cmd\/.*\.go:/ { next }
-              /\.gen\.go:/ { next }
-              {
-                statements += $2
-                if ($3 > 0) covered += $2
-              }
-              END {
-                if (statements > 0) {
-                  coverage = 100.0 * covered / statements
-                  printf "%.1f", coverage
-                } else {
-                  print "0.0"
-                }
-              }
-            ' coverage.out)
-
->>>>>>> 6d639e6 (feat: Add coverage exclusions in Generate coverage)
             if [ -z "$pct" ]; then
               echo "WARNING: Could not calculate coverage"
               echo "COVERAGE_PCT=0" >> "$GITHUB_ENV"
             else
               echo "Filtered coverage (excluding test/generated/cmd): $pct%"
               echo "COVERAGE_PCT=$pct" >> "$GITHUB_ENV"
-<<<<<<< HEAD
-=======
-              echo "Coverage with exclusions (matching SonarCloud): $pct%"
->>>>>>> 6d639e6 (feat: Add coverage exclusions in Generate coverage)
             fi
           fi
+          
+          # Cleanup workspace
+          echo "Cleaning up workspace..."
+          rm -f go.work go.work.sum
 
       - name: Enforce coverage threshold
         continue-on-error: true


### PR DESCRIPTION
## Description
- This PR enforces coverage threshold
- Steps Changed: Generate coverage and Enforce Threshold.
- Note: Ignore Sonar scan error as it is running from fork.

## Related Issues
- Refs CPLYTM-1078
- Refs CPLYTM-1090 - Dependent on previously https://github.com/complytime/complybeacon/pull/36
- Use the above workflow and add the enforce scan to the workflow
## Changes
- `.github/workflows/test-coverage.yml`