### PR TITLE
ci: upgrade codeql-action to v4

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -158,7 +158,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload vulnerability scan results
-        uses: github/codeql-action/upload-sarif@fbed2d2d53d0343436c1d6332dae0b38394d3917 # v3.30.7
+        uses: github/codeql-action/upload-sarif@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4
         with:
           sarif_file: trivy-results.sarif
           category: ${{ matrix.name }}-vulnerabilities


### PR DESCRIPTION
Anticipating a deprecation as recommended here:

- https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

Other repositories are already using v4 for some time:

- https://github.com/complytime/complyscribe/blob/main/.github/workflows/scorecard.yml#L47
- https://github.com/complytime/org-infra/blob/main/.github/workflows/reusable_security.yml#L48