### PR TITLE
fix: updates container image package reference

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   detect-images:
  
-    if: github.repository == 'complytime/complybeacon'
+    if: github.repository == 'complytime/complytime-collector-components'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.mk-matrix.outputs.matrix }}
@@ -56,7 +56,7 @@ jobs:
             fi
             
             base="$(echo "$context" | sed 's|^\./||')"
-            image="ghcr.io/complytime/complybeacon-${base}"
+            image="ghcr.io/complytime/complytime-collector-components-${base}"
             # Containerfile path must be relative to repo root for docker/build-push-action
             full_containerfile_path="${context}/${containerfile}"
             entries+=( "{\"name\":\"${base}\",\"context\":\"${context}\",\"dockerfile\":\"${full_containerfile_path}\",\"image\":\"${image}\"}" )
@@ -75,7 +75,7 @@ jobs:
   build-and-push:
     needs: detect-images
     # Only run in the upstream repo (not forks) to prevent accidental publishing
-    if: ${{ fromJSON(needs.detect-images.outputs.matrix).include[0] != null && github.repository == 'complytime/complybeacon' }}
+    if: ${{ fromJSON(needs.detect-images.outputs.matrix).include[0] != null && github.repository == 'complytime/complytime-collector-components' }}
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(needs.detect-images.outputs.matrix) }}
@@ -102,7 +102,7 @@ jobs:
             latest=auto
           labels: |
             org.opencontainers.image.title=${{ matrix.name }}
-            org.opencontainers.image.description=ComplyBeacon ${{ matrix.name }} service
+            org.opencontainers.image.description=ComplyTime Collector Components ${{ matrix.name }} service
             org.opencontainers.image.vendor=ComplyTime
 
       - name: Log in to GHCR

--- a/compose.yaml
+++ b/compose.yaml
@@ -38,7 +38,7 @@ services:
         /run.sh
 
   compass:
-    image: ghcr.io/complytime/complybeacon-compass:latest
+    image: ghcr.io/complytime/complytime-collector-components-compass:latest
     build:
       context: .
       dockerfile: ./compass/images/Containerfile.compass
@@ -60,7 +60,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - S3_BUCKETNAME=${S3_BUCKETNAME}
       - S3_OBJ_DIR=${S3_OBJ_DIR}
-    image: ghcr.io/complytime/complybeacon-beacon-distro:latest
+    image: ghcr.io/complytime/complytime-collector-components-beacon-distro:latest
     build:
       context: ./beacon-distro
       dockerfile: Containerfile.collector


### PR DESCRIPTION
## Summary

This PR updates the image publishing workflow to reference the `complytime-collector-components` package namespace for consistency across the project. This will reduce concerns of migration issues. There were no existing packages/images published under `complybeacon-*` in GHCR (see review hints).

## Related Issues

- Related to Issue #75 

## Review Hints

- Testing for existing packages in the repo 
`podman pull ghcr.io/complytime/complybeacon-compass:latest`
- No packages available in the `complytime` GHCR 