### PR TITLE
chore: bump cosign-installer to v4

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -197,7 +197,7 @@ jobs:
 
       # STAGE 6: Sign image with Cosign
       - name: Install Cosign
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: Sign image (Stage 6 - Signing)
         env:


### PR DESCRIPTION
## Summary

Noticed once reviewing the https://github.com/complytime/complytime-collector-components/pull/81/changes where the comment was not aligned with the commit hash.
- https://github.com/sigstore/cosign-installer/releases


Instead of only align the version, lets use the last available version which is already used in other repository as well:
- https://github.com/complytime/org-infra/blob/main/.github/workflows/reusable_promote.yml#L94

## Related Issues

- Not an issue but keep CI dependencies more aligned.

## Review Hints

- Checking the version changelog should help to confirm no breaking changes in our context.