### PR TITLE
feat(ci): CPLYTM-1258 refactor publish workflow to use reusable workflows

### DIFF
--- a/.github/workflows/ci_publish_ghcr.yml
+++ b/.github/workflows/ci_publish_ghcr.yml
@@ -1,11 +1,20 @@
-# Best-practices pipeline combining security transparency (SBOM, attestations) with operational excellence (pre-push validation)
-name: Published Images to GHCR
+# Publish Images Production Workflow
+# ==================================
+# Multi-stage security pipeline for building, scanning, and publishing container images.
+#
+# Pipeline Flow:
+#   scan-source → [build-compass, build-beacon-distro] →
+#   [scan-image-compass, scan-image-beacon-distro] → [sign-compass, sign-beacon-distro]
+#
+# NOTE: Scorecard flags 'write' permissions but these are REQUIRED for image publishing
+# See: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+name: Publish Images to GHCR
 
 on:
   push:
     branches:
       - main
-    tags: ['v*.*.*']
     paths:
       - '**/Containerfile*'
       - '.github/workflows/**'
@@ -19,222 +28,201 @@ on:
         required: false
         default: false
 
+# Minimal permissions at workflow level; jobs declare what they need
 permissions:
-  contents: read
-  packages: write
-  id-token: write        # for OIDC (attestations / cosign keyless)
-  attestations: write    # publish provenance
-  security-events: write # for the Trivy SARIF step
+  contents: none
+  packages: none
+  id-token: none
+  attestations: none
+  security-events: none
+  actions: none
+
+# Prevent concurrent runs for the same ref (branch/tag)
+# Production: don't cancel in-progress runs to avoid partial deployments
+concurrency:
+  group: publish-images-ghcr-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  detect-images:
-    if: github.repository == 'complytime/complybeacon'
+  # ═══════════════════════════════════════════════════════════════════════════
+  # STAGE 1: PRE-BUILD SOURCE SCANNING (shift-left security)
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Catches vulnerabilities BEFORE building—fail fast, save CI time.
+  # Single scan covers entire repository (both components).
+  scan-source:
+    name: Pre-build Source Scan
+    permissions:
+      contents: read          # checkout source for scanning
+      packages: write         # reusable workflow's nested job requires write
+      security-events: write  # upload SARIF results
+      id-token: write         # OIDC for registry auth
+      actions: read           # access reusable workflow
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@main
+    with:
+      enable_osv: true
+      enable_trivy_source: true
+      enable_trivy_image: false
+      trivy_severity: HIGH,CRITICAL
+    secrets: inherit
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # STAGE 2: BUILD AND PUSH (parallel builds after source scan passes)
+  # ═══════════════════════════════════════════════════════════════════════════
+  build-compass:
+    name: Build Compass Image
+    needs: [scan-source]
+    permissions:
+      contents: read       # checkout source for build
+      packages: write      # push image to GHCR
+      id-token: write      # OIDC for registry auth
+      actions: read        # access reusable workflow
+      attestations: write  # publish build provenance
+    uses: complytime/org-infra/.github/workflows/reusable_push_ghcr.yml@main
+    with:
+      component_name: compass
+      containerfile_path: compass/images/Containerfile.compass
+      context_path: .
+      image_name: complytime/complybeacon-compass
+      image_description: ComplyBeacon Compass service
+      image_vendor: ComplyTime
+      force_rebuild: ${{ inputs.force_rebuild || false }}
+    secrets: inherit
+
+  build-beacon-distro:
+    name: Build Beacon Distro Image
+    needs: [scan-source]
+    permissions:
+      contents: read       # checkout source for build
+      packages: write      # push image to GHCR
+      id-token: write      # OIDC for registry auth
+      actions: read        # access reusable workflow
+      attestations: write  # publish build provenance
+    uses: complytime/org-infra/.github/workflows/reusable_push_ghcr.yml@main
+    with:
+      component_name: beacon-distro
+      containerfile_path: beacon-distro/Containerfile.collector
+      context_path: ./beacon-distro
+      image_name: complytime/complybeacon-beacon-distro
+      image_description: ComplyBeacon Beacon Distro collector
+      image_vendor: ComplyTime
+      force_rebuild: ${{ inputs.force_rebuild || false }}
+    secrets: inherit
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # STAGE 3: POST-BUILD IMAGE SCANNING
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Scans built images for OS package vulns, runtime deps, embedded secrets.
+  scan-image-compass:
+    name: Scan Compass Image
+    needs: [build-compass]
+    permissions:
+      contents: read          # reusable may checkout for config
+      packages: write         # pull image from GHCR
+      security-events: write  # upload SARIF results
+      id-token: write         # OIDC for registry auth
+      actions: read           # required by osv_scanner nested job
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@main
+    with:
+      enable_osv: false
+      enable_trivy_source: false
+      enable_trivy_image: true
+      image_ref: ${{ needs.build-compass.outputs.image }}:sha-${{ github.sha }}
+      image_digest: ${{ needs.build-compass.outputs.digest }}
+      trivy_severity: HIGH,CRITICAL
+    secrets: inherit
+
+  scan-image-beacon-distro:
+    name: Scan Beacon Distro Image
+    needs: [build-beacon-distro]
+    if: ${{ always() && needs.build-beacon-distro.result == 'success' }}
+    permissions:
+      contents: read          # reusable may checkout for config
+      packages: write         # pull image from GHCR
+      security-events: write  # upload SARIF results
+      id-token: write         # OIDC for registry auth
+      actions: read           # required by osv_scanner nested job
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@main
+    with:
+      enable_osv: false
+      enable_trivy_source: false
+      enable_trivy_image: true
+      image_ref: ${{ needs.build-beacon-distro.outputs.image }}:sha-${{ github.sha }}
+      image_digest: ${{ needs.build-beacon-distro.outputs.digest }}
+      trivy_severity: HIGH,CRITICAL
+    secrets: inherit
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # STAGE 4: SIGN AND VERIFY (keyless signing with Sigstore)
+  # ═══════════════════════════════════════════════════════════════════════════
+  sign-compass:
+    name: Sign Compass Image
+    needs: [build-compass, scan-image-compass]
+    permissions:
+      packages: write  # attach signature to image
+      id-token: write  # OIDC for keyless signing
+    uses: complytime/org-infra/.github/workflows/reusable_sign_and_verify.yml@main
+    with:
+      image_name: ${{ needs.build-compass.outputs.image }}
+      digest: ${{ needs.build-compass.outputs.digest }}
+      allowed_identity_regex: https://github.com/complytime/org-infra(/.*)?
+    secrets: inherit
+
+  sign-beacon-distro:
+    name: Sign Beacon Distro Image
+    needs: [build-beacon-distro, scan-image-beacon-distro]
+    permissions:
+      packages: write  # attach signature to image
+      id-token: write  # OIDC for keyless signing
+    uses: complytime/org-infra/.github/workflows/reusable_sign_and_verify.yml@main
+    with:
+      image_name: ${{ needs.build-beacon-distro.outputs.image }}
+      digest: ${{ needs.build-beacon-distro.outputs.digest }}
+      allowed_identity_regex: https://github.com/complytime/org-infra(/.*)?
+    secrets: inherit
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # STAGE 5: SUMMARY (provides unified status)
+  # ═══════════════════════════════════════════════════════════════════════════
+  summary:
+    name: Pipeline Summary
+    needs: [scan-source, build-compass, build-beacon-distro, scan-image-compass, scan-image-beacon-distro, sign-compass, sign-beacon-distro]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.mk-matrix.outputs.matrix }}
+    permissions:
+      contents: read  # minimal permission for summary generation
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - id: mk-matrix
-        shell: bash
+      - name: Generate Summary
+        env:
+          R_SRC: ${{ needs.scan-source.result }}
+          R_B1: ${{ needs.build-compass.result }}
+          R_B2: ${{ needs.build-beacon-distro.result }}
+          R_S1: ${{ needs.scan-image-compass.result }}
+          R_S2: ${{ needs.scan-image-beacon-distro.result }}
+          R_G1: ${{ needs.sign-compass.result }}
+          R_G2: ${{ needs.sign-beacon-distro.result }}
         run: |
-          set -euo pipefail
-          entries=()
+          icon() { case "$1" in success) echo "✅";; skipped) echo "⏭️";; *) echo "❌";; esac; }
 
-          # Auto-discover all Containerfiles
-          while IFS= read -r fullpath; do
-            dir="$(dirname "$fullpath")"
-            dir="${dir#./}"
-            file="$(basename "$fullpath")"
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## 🚀 Image Pipeline Summary
 
-            # Determine context (parent directory if in subdirectory like images/)
-            if [[ "$dir" == */images ]]; then
-              context="./${dir%/images}"
-              containerfile="images/${file}"
-            else
-              context="./${dir}"
-              containerfile="${file}"
-            fi
-
-            base="${context#./}"
-            image="ghcr.io/complytime/complybeacon-${base}"
-            # Containerfile path must be relative to repo root for docker/build-push-action
-            full_containerfile_path="${context}/${containerfile}"
-            entries+=( "{\"name\":\"${base}\",\"context\":\"${context}\",\"dockerfile\":\"${full_containerfile_path}\",\"image\":\"${image}\"}" )
-          done < <(find . -maxdepth 3 -type f -name 'Containerfile*' -not -path "./.github/*" -print | sort -u)
-
-          if [[ "${#entries[@]}" -eq 0 ]]; then
-            echo "No Containerfiles found. Producing empty matrix."
-            echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
-            exit 0
+          | Stage | Compass | Beacon Distro |
+          |-------|---------|---------------|
+          | Source Scan | $(icon "$R_SRC") | $(icon "$R_SRC") |
+          | Build | $(icon "$R_B1") | $(icon "$R_B2") |
+          | Image Scan | $(icon "$R_S1") | $(icon "$R_S2") |
+          | Sign | $(icon "$R_G1") | $(icon "$R_G2") |
+          EOF
+          if [[ "$R_B1" != "success" && "$R_B1" != "skipped" ]] || \
+             [[ "$R_B2" != "success" && "$R_B2" != "skipped" ]]; then
+            echo "⚠️ **One or more components failed.**" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
 
-          json="$(printf '{ "include": [ %s ] }' "$(IFS=,; echo "${entries[*]}")")"
-          echo "matrix=${json}" >> "$GITHUB_OUTPUT"
-          echo "Discovered matrix: ${json}"
+          ✅ **Pipeline completed successfully.**
 
-  build-and-push:
-    needs: detect-images
-    # Only run in the upstream repo (not forks) to prevent accidental publishing
-    if: ${{ fromJSON(needs.detect-images.outputs.matrix).include[0] != null && github.repository == 'complytime/complybeacon' }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJSON(needs.detect-images.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
-        with:
-          images: ${{ matrix.image }}
-          tags: |
-            # For semantic version tags (v1.2.3)
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            # For branch commits
-            type=ref,event=branch,suffix=-{{sha}}
-            type=sha,prefix=sha-
-            # For scheduled builds
-            type=schedule,pattern={{date 'YYYYMMDD-HHmmss'}},prefix=scheduled-
-            # Latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
-          flavor: |
-            latest=auto
-          labels: |
-            org.opencontainers.image.title=${{ matrix.name }}
-            org.opencontainers.image.description=ComplyBeacon ${{ matrix.name }} service
-            org.opencontainers.image.vendor=ComplyTime
-
-      - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-      # STAGE 1: Build locally first (don't push yet!)
-      - name: Build and load to Docker (Stage 1 - Local Build)
-        id: build-local
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          load: true              # Load into local Docker daemon
-          push: false             # DON'T push yet!
-          platforms: linux/amd64  # Single platform for testing
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          # Disable attestations for local build (incompatible with --load)
-          sbom: false
-          provenance: false
-
-      # STAGE 2: Critical security check - scan for secrets (WILL FAIL BUILD)
-      - name: Scan for secrets (Stage 2 - Secret Detection)
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-        with:
-          image-ref: ${{ matrix.image }}:${{ steps.meta.outputs.version }}
-          exit-code: 1            # FAIL the workflow if secrets found!
-          scanners: secret
-          severity: HIGH,CRITICAL,MEDIUM
-          format: table
-
-      # STAGE 3: Scan for vulnerabilities (for awareness, uploads to Security tab)
-      - name: Scan for vulnerabilities (Stage 3 - Vulnerability Scan)
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-        with:
-          image-ref: ${{ matrix.image }}:${{ steps.meta.outputs.version }}
-          format: sarif
-          output: trivy-results.sarif
-          vuln-type: 'os,library'
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-
-      - name: Upload vulnerability scan results
-        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
-        with:
-          sarif_file: trivy-results.sarif
-          category: ${{ matrix.name }}-vulnerabilities
-
-      # NOTE: E2E testing has been moved to feature/enhanced-img-e2e-testing branch
-      # and will be integrated in a future PR with comprehensive service testing
-
-      # STAGE 4: Multi-arch build and push (uses cache, super fast!)
-      - name: Build and push multi-arch (Stage 4 - Final Push)
-        id: build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          push: true              # NOW safe to push!
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha    # Uses cache from Stage 1
-          cache-to: type=gha,mode=max
-          sbom: true
-          provenance: mode=max
-          no-cache: ${{ github.event.inputs.force_rebuild == 'true' }}
-
-      - name: Export digest
-        id: digest
-        run: echo "digest=${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
-
-      # STAGE 5: Attestations for supply chain security
-      - name: Attest build provenance (Stage 5 - Attestations)
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f #  v3.2.0
-        with:
-          subject-name: ${{ matrix.image }}
-          subject-digest: ${{ steps.digest.outputs.digest }}
-          push-to-registry: true
-
-      # STAGE 6: Sign image with Cosign
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-
-      - name: Sign image (Stage 6 - Signing)
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          IMAGE_WITH_DIGEST="${{ matrix.image }}@${{ steps.digest.outputs.digest }}"
-          echo " Signing: $IMAGE_WITH_DIGEST"
-          cosign sign --yes "$IMAGE_WITH_DIGEST"
-
-      # STAGE 7: Verify signature (ensure signing worked!)
-      - name: Verify signature (Stage 7 - Verification)
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          IMAGE_WITH_DIGEST="${{ matrix.image }}@${{ steps.digest.outputs.digest }}"
-          echo "Verifying signature: $IMAGE_WITH_DIGEST"
-          cosign verify "$IMAGE_WITH_DIGEST" \
-            --certificate-identity-regexp="https://github\.com/${{ github.repository_owner }}/.*" \
-            --certificate-oidc-issuer=https://token.actions.githubusercontent.com
-          echo " Signature verified successfully!"
-
-      # Summary
-      - name: Published image summary
-        run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          ## Successfully Published Image
-
-          **Service:** ${{ matrix.name }}
-          **Image:** ${{ matrix.image }}
-          **Digest:** ${{ steps.digest.outputs.digest }}
-
-          ### Tags
-          \`\`\`
-          $(echo "${{ steps.meta.outputs.tags }}" | tr ',' '\n')
-          \`\`\`
-
-          ### Security Checks Passed
+          ### 🔒 Security Checks Passed
           - Secret scanning
           - Vulnerability scanning
           - SBOM generated


### PR DESCRIPTION
## Summary
Refactors the image publishing workflow to use centralized reusable workflows from `complytime/org-infra`.

## Changes
- **Reusable workflows**: Uses `reusable_vuln_scan.yml`, `reusable_push_ghcr.yml`, and `reusable_sign_and_verify.yml`
- **Multi-stage pipeline**: scan-source → build → scan-image → sign
- **Parallel builds**: Compass and Beacon Distro build concurrently after source scan
- **Pipeline summary**: Unified status table showing all stages

## Security
- Pre-build source scanning (shift-left)
- Post-build image scanning
- Keyless signing with Sigstore
- Minimal permissions at workflow level

## Review Hints
- This is a focused modification cleanup of the image publishing to ghcr workflow
- Also refer: https://github.com/complytime/complytime-collector-components/pull/110
- Test run: https://github.com/sonupreetam/image-publish-test/actions/runs/21458145995