### PR TITLE
feat: CPLYTM-1279 add OIDC extension for collector

### DIFF
--- a/beacon-distro/manifest.yaml
+++ b/beacon-distro/manifest.yaml
@@ -32,3 +32,6 @@ providers:
 
 connectors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector v0.144.0
+
+extensions:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension v0.144.0


### PR DESCRIPTION
## Summary
Add the OIDC extension for the collector.
This PR relates to the [Ansible playbook update](https://gitlab.cee.redhat.com/product-security/continuous-compliance/complybeacon-playbooks/-/merge_requests/3/diffs?commit_id=d31d30035703831e8cbf2fe243c8fd9cf6328e00).

## Related Issues
[CPLYTM-1279](https://issues.redhat.com/browse/CPLYTM-1279)


## Review Hints
- Before the OIDC configuration, it could get a status code 200 after sending the post request to the API endpoint.
- After the OIDC configuration, it could get a status code 401 after sending the post request to the API endpoint as above.
- It could get the status code 200 after getting the access token first and then send the post request with the token, 
`curl --request POST --url 'https://xxx/token' --header 'content-type: application/x-www-form-urlencoded' --data grant_type=client_credentials --data client_id=XX --data client_secret=XX | jq .access_token`
`curl -v -X POST https://api.example.com/eventsource/receiver -H "Content-Type: application/json" -H "Authorization: Bearer XXX" -d @hack/sampledata/evidence.json`

