### PR TITLE
feat: Group evidence log by policy.rule.id when exporting to AWS S3

### DIFF
--- a/docs/integration/Sync_Evidence2Hyperproof.md
+++ b/docs/integration/Sync_Evidence2Hyperproof.md
@@ -97,7 +97,6 @@ Create new **`SecureString`** parameters in the AWS Systems Manager (SSM) Parame
 3.  **Configure IAM Execution Role:**
     * Attach the managed policy `AmazonS3ReadOnlyAccess` (to allow Lambda to read the evidence logs).
     * Create and attach an inline policy granting `ssm:GetParameter` and `kms:Decrypt` permission to read the specific SSM parameters (`/hyperproof/CLIENT_ID`, `/hyperproof/CLIENT_SECRET`).
-    * Create and attach an inline policy granting `s3:DeleteObject` and `s3:PutObject` permission because we need to rename S3 object filename. 
 
     _Example Policy snippet_
     ```json
@@ -108,9 +107,7 @@ Create new **`SecureString`** parameters in the AWS Systems Manager (SSM) Parame
           "Sid": "VisualEditor0",
           "Effect": "Allow",
           "Action": [
-            "s3:PutObject",
-            "s3:GetObject",
-            "s3:DeleteObject"
+            "s3:GetObject"
           ],
           "Resource": "arn:aws:s3:::alex-hyperproof-test/*"  
         }

--- a/hack/demo/demo-config.yaml
+++ b/hack/demo/demo-config.yaml
@@ -91,6 +91,8 @@ processors:
           - set(attributes["policy.evaluation.result"], "Unknown") where ParseJSON(body)["status"] != nil and attributes["policy.evaluation.result"] == nil
           # Extract severity from OCSF evidence
           - set(attributes["severity"], ParseJSON(body)["severity"]) where ParseJSON(body)["severity"] != nil
+          # Set policy.rule.id as resource attribute for S3 partitioning
+          - set(resource.attributes["policy.rule.id"], attributes["policy.rule.id"]) where attributes["policy.rule.id"] != nil
 
 connectors:
   # SignalToMetrics: converts enriched logs to metrics (exporter from logs, receiver to metrics)
@@ -161,7 +163,11 @@ exporters:
       region: ${AWS_REGION}
       s3_bucket: ${S3_BUCKETNAME}
       s3_prefix: ${S3_OBJ_DIR}
+      unique_key_func_name: uuidv7
       s3_partition_format: ""
+      file_prefix: "evidence_"
+    resource_attrs_to_s3:
+      s3_prefix: "policy.rule.id"
 
 service:
   pipelines:


### PR DESCRIPTION
## Summary

Group evidence log by policy.rule.id when exporting to AWS S3

## Related Issues

- None

## Review Hints

- Group evidence log by policy.rule.id when exporting to AWS S3