### PR TITLE
fix: remove misconfig and follow container guide

### DIFF
--- a/beacon-distro/Containerfile.collector
+++ b/beacon-distro/Containerfile.collector
@@ -5,7 +5,7 @@
 
 # Stage 1: Certificate extraction
 FROM alpine:3.22 AS certs
-RUN apk --update add ca-certificates
+RUN apk --no-cache add ca-certificates
 
 # Stage 2: Build the OpenTelemetry Collector
 FROM golang:1.24.10 AS build-stage

--- a/compass/images/Containerfile.compass
+++ b/compass/images/Containerfile.compass
@@ -5,7 +5,7 @@
 
 # Stage 1: Certificate extraction
 FROM alpine:3.22 AS certs
-RUN apk --update add ca-certificates
+RUN apk --no-cache add ca-certificates
 
 # Stage 2: Build the Compass service
 FROM golang:1.24.5 AS build-stage


### PR DESCRIPTION
## Summary

Replace --update with --no-cache, which both updates the index and discards it after the install. The practical security impact is negligible in the exisiting containers, however, Trivy classifies this misconfiguration as "HIGH".

### Updates

- beacon-distro/Containerfile.collector  
- compass/images/Containerfile.compass 

### Review Hints
- https://github.com/complytime/community/blob/25414b81224af5bf38f40bd12d2f32e17c1854bf/CONTAINERS_GUIDE.md
- https://github.com/complytime/complytime-collector-components/security/code-scanning/78
- https://github.com/complytime/complytime-collector-components/security/code-scanning/75

