### PR TITLE
feat: add collector bearertokenauth extension

### DIFF
--- a/beacon-distro/manifest.yaml
+++ b/beacon-distro/manifest.yaml
@@ -35,3 +35,4 @@ connectors:
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension v0.144.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.144.0


### PR DESCRIPTION
## Summary
Add collector bearertokenauth extension.
This is needed for supporting Compass JWTauth.
The related [PR](https://github.com/complytime/complytime-collector-components/pull/141/) has been split into this PR and a new [PR](https://github.com/complytime/gemara-content-service/pull/5) to gemara-content-service.

