### PR TITLE
chore: Remove datasource management from terraform

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -17,6 +17,25 @@ services:
       - GF_AUTH_BASIC_ENABLED=false
     ports:
       - "3000:3000/tcp"
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: 'http://loki:3100'
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: true
+        EOF
+        /run.sh
 
   compass:
     build:

--- a/hack/demo/terraform/README.md
+++ b/hack/demo/terraform/README.md
@@ -46,8 +46,7 @@ hack/demo/
 ### Prerequisites
 
 1. Terraform installed (>= 1.0) - [Download](https://developer.hashicorp.com/terraform/install)
-2. Grafana running and accessible
-3. Loki datasource available
+2. Grafana running and accessible (with Loki datasource provisioned at startup)
 
 ### Local Development - Fast Track
 
@@ -73,7 +72,6 @@ cd hack/demo/terraform
 # Configure credentials
 export TF_VAR_grafana_url="https://grafana.example.com"
 export TF_VAR_grafana_auth="YOUR_API_KEY"
-export TF_VAR_loki_url="http://loki:3100"
 
 # Deploy
 terraform init
@@ -236,9 +234,8 @@ git commit -m "Update dashboard configuration"
 ### Prerequisites
 
 1. Terraform installed (v1.0+)
-2. Grafana instance running and accessible
+2. Grafana instance running and accessible (with Loki datasource provisioned at startup)
 3. Grafana API credentials (admin:password or API key)
-4. Loki instance configured as data source
 
 ### Configuration Methods
 
@@ -247,7 +244,6 @@ git commit -m "Update dashboard configuration"
 ```bash
 export TF_VAR_grafana_url="https://grafana.example.com"
 export TF_VAR_grafana_auth="YOUR_API_KEY"
-export TF_VAR_loki_url="http://loki:3100"
 
 terraform apply
 ```
@@ -258,7 +254,6 @@ terraform apply
 cat > terraform.tfvars <<EOF
 grafana_url  = "https://grafana.example.com"
 grafana_auth = "Bearer YOUR_API_KEY"
-loki_url     = "http://loki:3100"
 EOF
 
 terraform apply
@@ -269,8 +264,7 @@ terraform apply
 ```bash
 terraform apply \
   -var="grafana_url=https://grafana.example.com" \
-  -var="grafana_auth=Bearer YOUR_API_KEY" \
-  -var="loki_url=http://loki:3100"
+  -var="grafana_auth=Bearer YOUR_API_KEY"
 ```
 
 ### Using API Keys (Recommended)
@@ -299,6 +293,11 @@ terraform apply
 Dashboards are defined inline using HCL in `main.tf`:
 
 ```hcl
+# Look up the Loki datasource provisioned by Grafana at startup
+data "grafana_data_source" "loki" {
+  name = "Loki"
+}
+
 resource "grafana_dashboard" "compliance_evidence" {
   overwrite = true
 
@@ -313,7 +312,7 @@ resource "grafana_dashboard" "compliance_evidence" {
         type  = "stat"
         datasource = {
           type = "loki"
-          uid  = grafana_data_source.loki.uid  # Dynamic reference!
+          uid  = data.grafana_data_source.loki.uid  # Dynamic reference!
         }
         targets = [{
           expr = "sum(count_over_time({service_name=~\".+\"} [$__range]))"
@@ -326,7 +325,7 @@ resource "grafana_dashboard" "compliance_evidence" {
 
 **Benefits of Inline HCL:**
 
-- **Dynamic datasource references**: Uses `grafana_data_source.loki.uid` for automatic UID resolution
+- **Dynamic datasource references**: Uses `data.grafana_data_source.loki.uid` for automatic UID resolution
 - **Full version control**: Dashboard config is in HCL, part of your Terraform code
 - **Infrastructure as Code**: Leverage Terraform variables, functions, and conditionals
 - **Multi-environment support**: Easy to parameterize for different environments
@@ -456,14 +455,12 @@ terraform apply -var="environment=prod"
 
 ### 4. Dynamic Datasource References
 
-One of the biggest benefits of inline HCL dashboards:
+One of the biggest benefits of inline HCL dashboards — Terraform looks up the UID of the datasource provisioned by Grafana at startup rather than hardcoding it:
 
 ```hcl
-# Define datasource
-resource "grafana_data_source" "loki" {
-  type = "loki"
+# Look up the datasource provisioned by Grafana at startup
+data "grafana_data_source" "loki" {
   name = "Loki"
-  url  = var.loki_url
 }
 
 # Use in dashboard - automatically gets the correct UID!
@@ -476,7 +473,7 @@ resource "grafana_dashboard" "app" {
       {
         datasource = {
           type = "loki"
-          uid  = grafana_data_source.loki.uid  # Dynamic!
+          uid  = data.grafana_data_source.loki.uid  # Dynamic!
         }
         targets = [{
           expr = "{app=\"myapp\"}"
@@ -487,7 +484,7 @@ resource "grafana_dashboard" "app" {
 }
 ```
 
-If you recreate the datasource, the dashboard automatically gets the new UID!
+Terraform reads the UID assigned by Grafana — no need to manage the datasource lifecycle in Terraform.
 
 ---
 

--- a/hack/demo/terraform/main.tf
+++ b/hack/demo/terraform/main.tf
@@ -12,24 +12,9 @@ provider "grafana" {
   auth = var.grafana_auth
 }
 
-# Data source configuration
-resource "grafana_data_source" "loki" {
-  type       = "loki"
-  name       = "Loki"
-  url        = var.loki_url
-  is_default = true
-
-  json_data_encoded = jsonencode({})
-
-  lifecycle {
-    # Prevent Terraform from trying to recreate this if it exists
-    prevent_destroy = false
-  }
-}
-
-# Local variables
-locals {
-  loki_ds_uid = grafana_data_source.loki.uid
+# Look up the Loki datasource provisioned by Grafana at startup
+data "grafana_data_source" "loki" {
+  name = "Loki"
 }
 
 # Compliance Evidence Dashboard
@@ -91,13 +76,13 @@ resource "grafana_dashboard" "compliance_evidence" {
         }
         datasource = {
           type = "loki"
-          uid  = grafana_data_source.loki.uid
+          uid  = data.grafana_data_source.loki.uid
         }
         pluginVersion = "11.6.0"
         targets = [{
           datasource = {
             type = "loki"
-            uid  = grafana_data_source.loki.uid
+            uid  = data.grafana_data_source.loki.uid
           }
           editorMode = "code"
           # Count enriched evidence logs (have policy_evaluation_result from truthbeam - signaltometrics logs don't have this)
@@ -149,12 +134,12 @@ resource "grafana_dashboard" "compliance_evidence" {
         }
         datasource = {
           type = "loki"
-          uid  = grafana_data_source.loki.uid
+          uid  = data.grafana_data_source.loki.uid
         }
         targets = [{
           datasource = {
             type = "loki"
-            uid  = grafana_data_source.loki.uid
+            uid  = data.grafana_data_source.loki.uid
           }
           editorMode   = "code"
           # Query enriched evidence logs (have policy_evaluation_result from truthbeam - signaltometrics logs don't have this)
@@ -283,13 +268,13 @@ resource "grafana_dashboard" "compliance_evidence" {
         }
         datasource = {
           type = "loki"
-          uid  = grafana_data_source.loki.uid
+          uid  = data.grafana_data_source.loki.uid
         }
         pluginVersion = "11.6.0"
         targets = [{
           datasource = {
             type = "loki"
-            uid  = grafana_data_source.loki.uid
+            uid  = data.grafana_data_source.loki.uid
           }
           editorMode   = "code"
           # Query enriched evidence logs (have policy_engine_name from truthbeam - signaltometrics logs don't have policy_evaluation_result)
@@ -341,13 +326,13 @@ resource "grafana_dashboard" "compliance_evidence" {
         }
         datasource = {
           type = "loki"
-          uid  = grafana_data_source.loki.uid
+          uid  = data.grafana_data_source.loki.uid
         }
         pluginVersion = "11.6.0"
         targets = [{
           datasource = {
             type = "loki"
-            uid  = grafana_data_source.loki.uid
+            uid  = data.grafana_data_source.loki.uid
           }
           editorMode   = "code"
           # Query enriched evidence logs (have policy_rule_id from truthbeam - signaltometrics logs don't have policy_evaluation_result)
@@ -399,12 +384,12 @@ resource "grafana_dashboard" "compliance_evidence" {
         }
         datasource = {
           type = "loki"
-          uid  = grafana_data_source.loki.uid
+          uid  = data.grafana_data_source.loki.uid
         }
         targets = [{
           datasource = {
             type = "loki"
-            uid  = grafana_data_source.loki.uid
+            uid  = data.grafana_data_source.loki.uid
           }
           editorMode = "code"
           # Query enriched logs: real-time evidence rate per control (uses compliance_control_id from truthbeam when available, otherwise policy_rule_id)
@@ -465,13 +450,13 @@ resource "grafana_dashboard" "compliance_evidence" {
         }
         datasource = {
           type = "loki"
-          uid  = grafana_data_source.loki.uid
+          uid  = data.grafana_data_source.loki.uid
         }
         pluginVersion = "11.6.0"
         targets = [{
           datasource = {
             type = "loki"
-            uid  = grafana_data_source.loki.uid
+            uid  = data.grafana_data_source.loki.uid
           }
           editorMode = "code"
           # Query enriched logs: total evidence count per control (uses policy_rule_id)
@@ -525,12 +510,12 @@ resource "grafana_dashboard" "compliance_evidence" {
         }
         datasource = {
           type = "loki"
-          uid  = local.loki_ds_uid
+          uid  = data.grafana_data_source.loki.uid
         }
         targets = [{
           datasource = {
             type = "loki"
-            uid  = local.loki_ds_uid
+            uid  = data.grafana_data_source.loki.uid
           }
           expr         = "sum by (policy_evaluation_result) (count_over_time({service_name=~\".+\"} | json | policy_evaluation_result=~\".+\" [$__range]))"
           legendFormat = "{{policy_evaluation_result}}"
@@ -646,12 +631,12 @@ resource "grafana_dashboard" "compliance_evidence" {
         }
         datasource = {
           type = "loki"
-          uid  = local.loki_ds_uid
+          uid  = data.grafana_data_source.loki.uid
         }
         targets = [{
           datasource = {
             type = "loki"
-            uid  = local.loki_ds_uid
+            uid  = data.grafana_data_source.loki.uid
           }
           expr    = "sum by (compliance_control_id, policy_rule_id, policy_config_include) (count_over_time({service_name=~\".+\"} | json | policy_config_include=~\".+\" [$__range]))"
           format  = "table"

--- a/hack/demo/terraform/outputs.tf
+++ b/hack/demo/terraform/outputs.tf
@@ -5,5 +5,5 @@ output "dashboard_url" {
 
 output "loki_datasource_uid" {
   description = "UID of the Loki datasource"
-  value       = grafana_data_source.loki.uid
+  value       = data.grafana_data_source.loki.uid
 }

--- a/hack/demo/terraform/variables.tf
+++ b/hack/demo/terraform/variables.tf
@@ -10,9 +10,3 @@ variable "grafana_auth" {
   default     = "admin:admin"
   sensitive   = true
 }
-
-variable "loki_url" {
-  description = "Loki server URL"
-  type        = string
-  default     = "http://loki:3100"
-}


### PR DESCRIPTION
## Summary

Remove datasource management from terraform, provisioned loki as default datasource by Grafana at startup.

## Related Issues

- None

## Rationale 

When testing terraform against MP+ environment, found out that using  terraform create loki as Grafana datasouces not working. After some test, provisioned loki as default datasource by Grafana at startup is working. 

## Review Hints

- Remove datasource management from terraform.

- Provisioned loki as default datasource by Grafana at startup.
