### PR TITLE
ci: CPLYTM-1346 - add CRAP load analysis workflow

### DIFF
--- a/.github/workflows/ci_crapload.yml
+++ b/.github/workflows/ci_crapload.yml
@@ -1,0 +1,75 @@
+# CRAP Load Check
+# ===============
+# Runs CRAP load analysis on pull requests targeting main.
+# Consumes the reusable workflow from org-infra.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: CRAP Load Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  crapload:
+    name: CRAP Load Analysis
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@main
+    permissions:
+      contents: read
+
+  post-comment:
+    name: Post PR Comment
+    needs: crapload
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download comment body
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: crapload-analysis
+          path: artifact
+
+      - name: Post or update PR comment
+        continue-on-error: true
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const bodyPath = 'artifact/crapload-comment-body.md';
+            if (!fs.existsSync(bodyPath)) {
+              console.log('No comment body found. Skipping.');
+              return;
+            }
+            const body = fs.readFileSync(bodyPath, 'utf8');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const marker = '<!-- crapload-analysis-marker -->';
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

Add consumer workflow that references the centralized reusable CRAP load analysis workflow from org-infra.
Runs on pull requests targeting main to detect CRAP score regressions in Go code.
Includes a post-comment job that downloads the analysis artifact and posts results as a PR comment.

## Related Issues

- https://redhat.atlassian.net/browse/CPLYTM-1346

## Review Hints

- Depends on https://github.com/complytime/org-infra/pull/144
