### PR TITLE
feat: CPLYTM-1376 - add CRAP load monitoring targets and baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,91 @@ golangci-lint: ## Runs golangci-lint for all modules
 	@echo "--- All linting passed! ---"
 .PHONY: golangci-lint
 
+#------------------------------------------------------------------------------
+# CRAP Load Monitoring
+#------------------------------------------------------------------------------
+
+GAZE_VERSION ?= latest
+GAZE_COVERPROFILE := coverage.out
+GAZE_NEW_FUNC_THRESHOLD ?= 30
+
+ensure-gaze: ## Install gaze if not present
+	@command -v gaze >/dev/null 2>&1 || \
+		(echo "Installing gaze..." && go install github.com/unbound-force/gaze/cmd/gaze@$(GAZE_VERSION))
+.PHONY: ensure-gaze
+
+crapload: ensure-gaze test ## Run CRAP and GazeCRAP analysis (human-readable) for all modules
+	@for m in $(MODULES); do \
+		echo "========================================================================================================="; \
+		echo "CRAP analysis for $$m..."; \
+		echo "========================================================================================================="; \
+		(cd $$m && gaze crap --format=text --coverprofile=$(GAZE_COVERPROFILE) ./...); \
+	done
+.PHONY: crapload
+
+crapload-baseline: ensure-gaze test ## Generate baseline thresholds in .gaze/baseline.json for all modules
+	@for m in $(MODULES); do \
+		echo "Generating baseline for $$m..."; \
+		mkdir -p $$m/.gaze; \
+		MODULE_ROOT=$$(cd $$m && pwd); \
+		(cd $$m && gaze crap --format=json --coverprofile=$(GAZE_COVERPROFILE) ./... | \
+			jq --arg root "$$MODULE_ROOT/" '(.scores[],.summary.worst_crap[]?,.summary.worst_gaze_crap[]?) |= (.file |= ltrimstr($$root))' > .gaze/baseline.json); \
+		echo "Baseline written to $$m/.gaze/baseline.json"; \
+	done
+.PHONY: crapload-baseline
+
+crapload-check: ensure-gaze test ## Check for CRAP regressions against baseline for all modules
+	@TOTAL_REGRESSIONS=0; \
+	for m in $(MODULES); do \
+		echo "========================================================================================================="; \
+		echo "Checking CRAP regressions for $$m..."; \
+		echo "========================================================================================================="; \
+		BASELINE=$$m/.gaze/baseline.json; \
+		if [ ! -f $$BASELINE ]; then \
+			echo "ERROR: Baseline file $$BASELINE not found. Run 'make crapload-baseline' first."; \
+			exit 1; \
+		fi; \
+		MODULE_ROOT=$$(cd $$m && pwd); \
+		(cd $$m && gaze crap --format=json --coverprofile=$(GAZE_COVERPROFILE) ./... | \
+			jq --arg root "$$MODULE_ROOT/" '(.scores[],.summary.worst_crap[]?,.summary.worst_gaze_crap[]?) |= (.file |= ltrimstr($$root))' > /tmp/crapload-current.json); \
+		echo "Comparing against baseline..."; \
+		jq -r '.scores[] | "\(.file):\(.function) \(.crap) \(.gaze_crap // 0)"' $$BASELINE | sort > /tmp/crapload-baseline.txt; \
+		jq -r '.scores[] | "\(.file):\(.function) \(.crap) \(.gaze_crap // 0)"' /tmp/crapload-current.json | sort > /tmp/crapload-current.txt; \
+		REGRESSIONS=0; \
+		while IFS=' ' read -r func crap gaze_crap; do \
+			baseline_crap=$$(grep -F "$$func " /tmp/crapload-baseline.txt | head -1 | awk '{print $$2}'); \
+			baseline_gaze=$$(grep -F "$$func " /tmp/crapload-baseline.txt | head -1 | awk '{print $$3}'); \
+			if [ -z "$$baseline_crap" ]; then \
+				if [ "$$(echo "$$crap > $(GAZE_NEW_FUNC_THRESHOLD)" | bc -l)" = "1" ]; then \
+					echo "NEW FUNCTION VIOLATION: $$func CRAP=$$crap (threshold=$(GAZE_NEW_FUNC_THRESHOLD))"; \
+					REGRESSIONS=$$((REGRESSIONS + 1)); \
+				fi; \
+			else \
+				if [ "$$(echo "$$crap > $$baseline_crap" | bc -l)" = "1" ]; then \
+					echo "REGRESSION: $$func CRAP $$baseline_crap -> $$crap"; \
+					REGRESSIONS=$$((REGRESSIONS + 1)); \
+				fi; \
+				if [ "$$(echo "$$gaze_crap > $$baseline_gaze" | bc -l)" = "1" ]; then \
+					echo "REGRESSION: $$func GazeCRAP $$baseline_gaze -> $$gaze_crap"; \
+					REGRESSIONS=$$((REGRESSIONS + 1)); \
+				fi; \
+			fi; \
+		done < /tmp/crapload-current.txt; \
+		TOTAL_REGRESSIONS=$$((TOTAL_REGRESSIONS + REGRESSIONS)); \
+		if [ $$REGRESSIONS -gt 0 ]; then \
+			echo "$$m: $$REGRESSIONS regression(s) detected"; \
+		else \
+			echo "$$m: No regressions detected"; \
+		fi; \
+	done; \
+	if [ $$TOTAL_REGRESSIONS -gt 0 ]; then \
+		echo "FAIL: $$TOTAL_REGRESSIONS total regression(s) detected"; \
+		exit 1; \
+	else \
+		echo "PASS: No regressions detected across all modules"; \
+	fi
+.PHONY: crapload-check
+
 # ------------------------------------------------------------------------------
 # Help Target
 # Prints a friendly help message.

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ crapload-baseline: ensure-gaze test ## Generate baseline thresholds in .gaze/bas
 		echo "Generating baseline for $$m..."; \
 		mkdir -p $$m/.gaze; \
 		MODULE_ROOT=$$(cd $$m && pwd); \
-		(cd $$m && gaze crap --format=json --coverprofile=$(GAZE_COVERPROFILE) ./... | \
+		(cd $$m && gaze crap --format=json --coverprofile=$(GAZE_COVERPROFILE) ./... 2>/dev/null | \
 			jq --arg root "$$MODULE_ROOT/" '(.scores[],.summary.worst_crap[]?,.summary.worst_gaze_crap[]?) |= (.file |= ltrimstr($$root))' > .gaze/baseline.json); \
 		echo "Baseline written to $$m/.gaze/baseline.json"; \
 	done
@@ -248,31 +248,31 @@ crapload-check: ensure-gaze test ## Check for CRAP regressions against baseline 
 			exit 1; \
 		fi; \
 		MODULE_ROOT=$$(cd $$m && pwd); \
-		(cd $$m && gaze crap --format=json --coverprofile=$(GAZE_COVERPROFILE) ./... | \
+		(cd $$m && gaze crap --format=json --coverprofile=$(GAZE_COVERPROFILE) ./... 2>/dev/null | \
 			jq --arg root "$$MODULE_ROOT/" '(.scores[],.summary.worst_crap[]?,.summary.worst_gaze_crap[]?) |= (.file |= ltrimstr($$root))' > /tmp/crapload-current.json); \
 		echo "Comparing against baseline..."; \
-		jq -r '.scores[] | "\(.file):\(.function) \(.crap) \(.gaze_crap // 0)"' $$BASELINE | sort > /tmp/crapload-baseline.txt; \
-		jq -r '.scores[] | "\(.file):\(.function) \(.crap) \(.gaze_crap // 0)"' /tmp/crapload-current.json | sort > /tmp/crapload-current.txt; \
+		jq -r '.scores[] | "\(.file):\(.function)\t\(.crap)\t\(.gaze_crap // 0)"' $$BASELINE | sort > /tmp/crapload-baseline.tsv; \
 		REGRESSIONS=0; \
-		while IFS=' ' read -r func crap gaze_crap; do \
-			baseline_crap=$$(grep -F "$$func " /tmp/crapload-baseline.txt | head -1 | awk '{print $$2}'); \
-			baseline_gaze=$$(grep -F "$$func " /tmp/crapload-baseline.txt | head -1 | awk '{print $$3}'); \
-			if [ -z "$$baseline_crap" ]; then \
+		while IFS=$$'\t' read -r func crap gaze_crap; do \
+			baseline_line=$$(grep -F "$$func	" /tmp/crapload-baseline.tsv | head -1 || true); \
+			if [ -z "$$baseline_line" ]; then \
 				if [ "$$(echo "$$crap > $(GAZE_NEW_FUNC_THRESHOLD)" | bc -l)" = "1" ]; then \
 					echo "NEW FUNCTION VIOLATION: $$func CRAP=$$crap (threshold=$(GAZE_NEW_FUNC_THRESHOLD))"; \
 					REGRESSIONS=$$((REGRESSIONS + 1)); \
 				fi; \
 			else \
-				if [ "$$(echo "$$crap > $$baseline_crap" | bc -l)" = "1" ]; then \
-					echo "REGRESSION: $$func CRAP $$baseline_crap -> $$crap"; \
+				b_crap=$$(echo "$$baseline_line" | cut -f2); \
+				b_gaze=$$(echo "$$baseline_line" | cut -f3); \
+				if [ "$$(echo "$$crap > $$b_crap" | bc -l)" = "1" ]; then \
+					echo "REGRESSION: $$func CRAP $$b_crap -> $$crap"; \
 					REGRESSIONS=$$((REGRESSIONS + 1)); \
 				fi; \
-				if [ "$$(echo "$$gaze_crap > $$baseline_gaze" | bc -l)" = "1" ]; then \
-					echo "REGRESSION: $$func GazeCRAP $$baseline_gaze -> $$gaze_crap"; \
+				if [ "$$(echo "$$gaze_crap > $$b_gaze" | bc -l)" = "1" ]; then \
+					echo "REGRESSION: $$func GazeCRAP $$b_gaze -> $$gaze_crap"; \
 					REGRESSIONS=$$((REGRESSIONS + 1)); \
 				fi; \
 			fi; \
-		done < /tmp/crapload-current.txt; \
+		done < <(jq -r '.scores[] | "\(.file):\(.function)\t\(.crap)\t\(.gaze_crap // 0)"' /tmp/crapload-current.json | sort); \
 		TOTAL_REGRESSIONS=$$((TOTAL_REGRESSIONS + REGRESSIONS)); \
 		if [ $$REGRESSIONS -gt 0 ]; then \
 			echo "$$m: $$REGRESSIONS regression(s) detected"; \

--- a/proofwatch/.gaze/baseline.json
+++ b/proofwatch/.gaze/baseline.json
@@ -1,0 +1,428 @@
+{
+  "scores": [
+    {
+      "package": "main",
+      "function": "generateGemaraLog",
+      "file": "cmd/validate-logs/main.go",
+      "line": 20,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "main",
+      "function": "generateOCSFLog",
+      "file": "cmd/validate-logs/main.go",
+      "line": 48,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "main",
+      "function": "createLogFromAttributes",
+      "file": "cmd/validate-logs/main.go",
+      "line": 77,
+      "complexity": 5,
+      "line_coverage": 0,
+      "crap": 30
+    },
+    {
+      "package": "main",
+      "function": "simulateTruthBeamEnrichment",
+      "file": "cmd/validate-logs/main.go",
+      "line": 112,
+      "complexity": 8,
+      "line_coverage": 0,
+      "crap": 72
+    },
+    {
+      "package": "main",
+      "function": "convertToWeaverFormat",
+      "file": "cmd/validate-logs/main.go",
+      "line": 177,
+      "complexity": 4,
+      "line_coverage": 0,
+      "crap": 20
+    },
+    {
+      "package": "main",
+      "function": "valueToString",
+      "file": "cmd/validate-logs/main.go",
+      "line": 210,
+      "complexity": 8,
+      "line_coverage": 0,
+      "crap": 72
+    },
+    {
+      "package": "main",
+      "function": "stringPtr",
+      "file": "cmd/validate-logs/main.go",
+      "line": 235,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "main",
+      "function": "main",
+      "file": "cmd/validate-logs/main.go",
+      "line": 239,
+      "complexity": 12,
+      "line_coverage": 0,
+      "crap": 156
+    },
+    {
+      "package": "proofwatch",
+      "function": "WithMeterProvider",
+      "file": "config.go",
+      "line": 19,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "proofwatch",
+      "function": "WithLoggerProvider",
+      "file": "config.go",
+      "line": 29,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "proofwatch",
+      "function": "WithTracerProvider",
+      "file": "config.go",
+      "line": 39,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "proofwatch",
+      "function": "(GemaraEvidence).ToJSON",
+      "file": "gemara.go",
+      "line": 21,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "proofwatch",
+      "function": "(GemaraEvidence).Attributes",
+      "file": "gemara.go",
+      "line": 25,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "proofwatch",
+      "function": "(GemaraEvidence).Timestamp",
+      "file": "gemara.go",
+      "line": 46,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "metrics",
+      "function": "NewEvidenceObserver",
+      "file": "internal/metrics/observer.go",
+      "line": 19,
+      "complexity": 3,
+      "line_coverage": 77.77777777777777,
+      "crap": 3.0987654320987654,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "metrics",
+      "function": "(*EvidenceObserver).Dropped",
+      "file": "internal/metrics/observer.go",
+      "line": 45,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "metrics",
+      "function": "(*EvidenceObserver).Processed",
+      "file": "internal/metrics/observer.go",
+      "line": 49,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "proofwatch",
+      "function": "(OCSFEvidence).Timestamp",
+      "file": "ocsf.go",
+      "line": 28,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "proofwatch",
+      "function": "(OCSFEvidence).ToJSON",
+      "file": "ocsf.go",
+      "line": 32,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "proofwatch",
+      "function": "(OCSFEvidence).Attributes",
+      "file": "ocsf.go",
+      "line": 36,
+      "complexity": 6,
+      "line_coverage": 87.5,
+      "crap": 6.0703125
+    },
+    {
+      "package": "proofwatch",
+      "function": "stringVal",
+      "file": "ocsf.go",
+      "line": 68,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "proofwatch",
+      "function": "mapEvaluationStatus",
+      "file": "ocsf.go",
+      "line": 77,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "proofwatch",
+      "function": "mapEnforcementAction",
+      "file": "ocsf.go",
+      "line": 92,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "proofwatch",
+      "function": "mapEnforcementStatus",
+      "file": "ocsf.go",
+      "line": 110,
+      "complexity": 16,
+      "line_coverage": 100,
+      "crap": 16
+    },
+    {
+      "package": "proofwatch",
+      "function": "validateEvidenceFields",
+      "file": "ocsf.go",
+      "line": 135,
+      "complexity": 7,
+      "line_coverage": 100,
+      "crap": 7
+    },
+    {
+      "package": "proofwatch",
+      "function": "NewProofWatch",
+      "file": "proofwatch.go",
+      "line": 30,
+      "complexity": 3,
+      "line_coverage": 87.5,
+      "crap": 3.017578125,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "proofwatch",
+      "function": "(*ProofWatch).Log",
+      "file": "proofwatch.go",
+      "line": 55,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "proofwatch",
+      "function": "(*ProofWatch).LogWithSeverity",
+      "file": "proofwatch.go",
+      "line": 60,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "proofwatch",
+      "function": "ToLogKeyValues",
+      "file": "proofwatch.go",
+      "line": 91,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "proofwatch",
+      "function": "Version",
+      "file": "proofwatch.go",
+      "line": 100,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
+    }
+  ],
+  "summary": {
+    "total_functions": 30,
+    "avg_complexity": 3.6,
+    "avg_line_coverage": 68.42592592592592,
+    "avg_crap": 14.172888535236627,
+    "crapload": 6,
+    "crap_threshold": 15,
+    "gaze_crapload": 0,
+    "gaze_crap_threshold": 15,
+    "avg_gaze_crap": 6,
+    "avg_contract_coverage": 0,
+    "quadrant_counts": {
+      "Q1_Safe": 10
+    },
+    "worst_crap": [
+      {
+        "package": "main",
+        "function": "main",
+        "file": "cmd/validate-logs/main.go",
+        "line": 239,
+        "complexity": 12,
+        "line_coverage": 0,
+        "crap": 156
+      },
+      {
+        "package": "main",
+        "function": "simulateTruthBeamEnrichment",
+        "file": "cmd/validate-logs/main.go",
+        "line": 112,
+        "complexity": 8,
+        "line_coverage": 0,
+        "crap": 72
+      },
+      {
+        "package": "main",
+        "function": "valueToString",
+        "file": "cmd/validate-logs/main.go",
+        "line": 210,
+        "complexity": 8,
+        "line_coverage": 0,
+        "crap": 72
+      },
+      {
+        "package": "main",
+        "function": "createLogFromAttributes",
+        "file": "cmd/validate-logs/main.go",
+        "line": 77,
+        "complexity": 5,
+        "line_coverage": 0,
+        "crap": 30
+      },
+      {
+        "package": "main",
+        "function": "convertToWeaverFormat",
+        "file": "cmd/validate-logs/main.go",
+        "line": 177,
+        "complexity": 4,
+        "line_coverage": 0,
+        "crap": 20
+      }
+    ],
+    "worst_gaze_crap": [
+      {
+        "package": "metrics",
+        "function": "NewEvidenceObserver",
+        "file": "internal/metrics/observer.go",
+        "line": 19,
+        "complexity": 3,
+        "line_coverage": 77.77777777777777,
+        "crap": 3.0987654320987654,
+        "contract_coverage": 0,
+        "gaze_crap": 12,
+        "quadrant": "Q1_Safe"
+      },
+      {
+        "package": "proofwatch",
+        "function": "NewProofWatch",
+        "file": "proofwatch.go",
+        "line": 30,
+        "complexity": 3,
+        "line_coverage": 87.5,
+        "crap": 3.017578125,
+        "contract_coverage": 0,
+        "gaze_crap": 12,
+        "quadrant": "Q1_Safe"
+      },
+      {
+        "package": "proofwatch",
+        "function": "WithMeterProvider",
+        "file": "config.go",
+        "line": 19,
+        "complexity": 2,
+        "line_coverage": 100,
+        "crap": 2,
+        "contract_coverage": 0,
+        "gaze_crap": 6,
+        "quadrant": "Q1_Safe"
+      },
+      {
+        "package": "proofwatch",
+        "function": "WithLoggerProvider",
+        "file": "config.go",
+        "line": 29,
+        "complexity": 2,
+        "line_coverage": 100,
+        "crap": 2,
+        "contract_coverage": 0,
+        "gaze_crap": 6,
+        "quadrant": "Q1_Safe"
+      },
+      {
+        "package": "proofwatch",
+        "function": "WithTracerProvider",
+        "file": "config.go",
+        "line": 39,
+        "complexity": 2,
+        "line_coverage": 100,
+        "crap": 2,
+        "contract_coverage": 0,
+        "gaze_crap": 6,
+        "quadrant": "Q1_Safe"
+      }
+    ]
+  }
+}

--- a/proofwatch/.gaze/baseline.json
+++ b/proofwatch/.gaze/baseline.json
@@ -25,7 +25,8 @@
       "line": 77,
       "complexity": 5,
       "line_coverage": 0,
-      "crap": 30
+      "crap": 30,
+      "fix_strategy": "add_tests"
     },
     {
       "package": "main",
@@ -34,7 +35,8 @@
       "line": 112,
       "complexity": 8,
       "line_coverage": 0,
-      "crap": 72
+      "crap": 72,
+      "fix_strategy": "add_tests"
     },
     {
       "package": "main",
@@ -43,7 +45,8 @@
       "line": 177,
       "complexity": 4,
       "line_coverage": 0,
-      "crap": 20
+      "crap": 20,
+      "fix_strategy": "add_tests"
     },
     {
       "package": "main",
@@ -52,7 +55,8 @@
       "line": 210,
       "complexity": 8,
       "line_coverage": 0,
-      "crap": 72
+      "crap": 72,
+      "fix_strategy": "add_tests"
     },
     {
       "package": "main",
@@ -70,7 +74,8 @@
       "line": 239,
       "complexity": 12,
       "line_coverage": 0,
-      "crap": 156
+      "crap": 156,
+      "fix_strategy": "add_tests"
     },
     {
       "package": "proofwatch",
@@ -157,7 +162,8 @@
       "crap": 1,
       "contract_coverage": 0,
       "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "no_effects_detected"
     },
     {
       "package": "metrics",
@@ -169,7 +175,8 @@
       "crap": 1,
       "contract_coverage": 0,
       "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "no_effects_detected"
     },
     {
       "package": "proofwatch",
@@ -232,7 +239,8 @@
       "line": 110,
       "complexity": 16,
       "line_coverage": 100,
-      "crap": 16
+      "crap": 16,
+      "fix_strategy": "decompose"
     },
     {
       "package": "proofwatch",
@@ -274,7 +282,8 @@
       "crap": 2,
       "contract_coverage": 0,
       "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "no_effects_detected"
     },
     {
       "package": "proofwatch",
@@ -284,8 +293,8 @@
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2,
-      "contract_coverage": 0,
-      "gaze_crap": 6,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
       "quadrant": "Q1_Safe"
     },
     {
@@ -296,8 +305,8 @@
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
       "quadrant": "Q1_Safe"
     }
   ],
@@ -310,10 +319,14 @@
     "crap_threshold": 15,
     "gaze_crapload": 0,
     "gaze_crap_threshold": 15,
-    "avg_gaze_crap": 6,
-    "avg_contract_coverage": 0,
+    "avg_gaze_crap": 5.5,
+    "avg_contract_coverage": 20,
     "quadrant_counts": {
       "Q1_Safe": 10
+    },
+    "fix_strategy_counts": {
+      "add_tests": 5,
+      "decompose": 1
     },
     "worst_crap": [
       {
@@ -323,7 +336,8 @@
         "line": 239,
         "complexity": 12,
         "line_coverage": 0,
-        "crap": 156
+        "crap": 156,
+        "fix_strategy": "add_tests"
       },
       {
         "package": "main",
@@ -332,7 +346,8 @@
         "line": 112,
         "complexity": 8,
         "line_coverage": 0,
-        "crap": 72
+        "crap": 72,
+        "fix_strategy": "add_tests"
       },
       {
         "package": "main",
@@ -341,7 +356,8 @@
         "line": 210,
         "complexity": 8,
         "line_coverage": 0,
-        "crap": 72
+        "crap": 72,
+        "fix_strategy": "add_tests"
       },
       {
         "package": "main",
@@ -350,7 +366,8 @@
         "line": 77,
         "complexity": 5,
         "line_coverage": 0,
-        "crap": 30
+        "crap": 30,
+        "fix_strategy": "add_tests"
       },
       {
         "package": "main",
@@ -359,7 +376,8 @@
         "line": 177,
         "complexity": 4,
         "line_coverage": 0,
-        "crap": 20
+        "crap": 20,
+        "fix_strategy": "add_tests"
       }
     ],
     "worst_gaze_crap": [
@@ -422,6 +440,62 @@
         "contract_coverage": 0,
         "gaze_crap": 6,
         "quadrant": "Q1_Safe"
+      }
+    ],
+    "recommended_actions": [
+      {
+        "function": "main",
+        "package": "main",
+        "file": "/home/maburgha/GIT/ProdSec/complytime-collector-components/proofwatch/cmd/validate-logs/main.go",
+        "line": 239,
+        "fix_strategy": "add_tests",
+        "crap": 156,
+        "complexity": 12
+      },
+      {
+        "function": "simulateTruthBeamEnrichment",
+        "package": "main",
+        "file": "/home/maburgha/GIT/ProdSec/complytime-collector-components/proofwatch/cmd/validate-logs/main.go",
+        "line": 112,
+        "fix_strategy": "add_tests",
+        "crap": 72,
+        "complexity": 8
+      },
+      {
+        "function": "valueToString",
+        "package": "main",
+        "file": "/home/maburgha/GIT/ProdSec/complytime-collector-components/proofwatch/cmd/validate-logs/main.go",
+        "line": 210,
+        "fix_strategy": "add_tests",
+        "crap": 72,
+        "complexity": 8
+      },
+      {
+        "function": "createLogFromAttributes",
+        "package": "main",
+        "file": "/home/maburgha/GIT/ProdSec/complytime-collector-components/proofwatch/cmd/validate-logs/main.go",
+        "line": 77,
+        "fix_strategy": "add_tests",
+        "crap": 30,
+        "complexity": 5
+      },
+      {
+        "function": "convertToWeaverFormat",
+        "package": "main",
+        "file": "/home/maburgha/GIT/ProdSec/complytime-collector-components/proofwatch/cmd/validate-logs/main.go",
+        "line": 177,
+        "fix_strategy": "add_tests",
+        "crap": 20,
+        "complexity": 4
+      },
+      {
+        "function": "mapEnforcementStatus",
+        "package": "proofwatch",
+        "file": "/home/maburgha/GIT/ProdSec/complytime-collector-components/proofwatch/ocsf.go",
+        "line": 110,
+        "fix_strategy": "decompose",
+        "crap": 16,
+        "complexity": 16
       }
     ]
   }

--- a/truthbeam/.gaze/baseline.json
+++ b/truthbeam/.gaze/baseline.json
@@ -1,0 +1,360 @@
+{
+  "scores": [
+    {
+      "package": "truthbeam",
+      "function": "(*Config).Validate",
+      "file": "config.go",
+      "line": 23,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5,
+      "contract_coverage": 0,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified"
+    },
+    {
+      "package": "truthbeam",
+      "function": "NewFactory",
+      "file": "factory.go",
+      "line": 20,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "truthbeam",
+      "function": "createDefaultConfig",
+      "file": "factory.go",
+      "line": 27,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "truthbeam",
+      "function": "createLogsProcessor",
+      "file": "factory.go",
+      "line": 43,
+      "complexity": 2,
+      "line_coverage": 0,
+      "crap": 6
+    },
+    {
+      "package": "applier",
+      "function": "NewApplier",
+      "file": "internal/applier/applier.go",
+      "line": 19,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "applier",
+      "function": "(*Applier).Apply",
+      "file": "internal/applier/applier.go",
+      "line": 27,
+      "complexity": 7,
+      "line_coverage": 100,
+      "crap": 7,
+      "contract_coverage": 0,
+      "gaze_crap": 56,
+      "quadrant": "Q3_SimpleButUnderspecified"
+    },
+    {
+      "package": "applier",
+      "function": "(*Applier).Extract",
+      "file": "internal/applier/applier.go",
+      "line": 68,
+      "complexity": 7,
+      "line_coverage": 90.47619047619048,
+      "crap": 7.042328042328042,
+      "contract_coverage": 0,
+      "gaze_crap": 56,
+      "quadrant": "Q3_SimpleButUnderspecified"
+    },
+    {
+      "package": "applier",
+      "function": "(Status).String",
+      "file": "internal/applier/status.go",
+      "line": 29,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "applier",
+      "function": "parseResult",
+      "file": "internal/applier/status.go",
+      "line": 33,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
+    },
+    {
+      "package": "applier",
+      "function": "mapResult",
+      "file": "internal/applier/status.go",
+      "line": 48,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "client",
+      "function": "NewCacheableClient",
+      "file": "internal/client/cacheable.go",
+      "line": 30,
+      "complexity": 4,
+      "line_coverage": 87.5,
+      "crap": 4.03125,
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified"
+    },
+    {
+      "package": "client",
+      "function": "NewCacheableClientWithCache",
+      "file": "internal/client/cacheable.go",
+      "line": 49,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "client",
+      "function": "cacheKey",
+      "file": "internal/client/cacheable.go",
+      "line": 58,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "client",
+      "function": "(*CacheableClient).Retrieve",
+      "file": "internal/client/cacheable.go",
+      "line": 64,
+      "complexity": 4,
+      "line_coverage": 92.3076923076923,
+      "crap": 4.007282658170232,
+      "contract_coverage": 0,
+      "gaze_crap": 20,
+      "quadrant": "Q3_SimpleButUnderspecified"
+    },
+    {
+      "package": "client",
+      "function": "(*CacheableClient).callEnrich",
+      "file": "internal/client/cacheable.go",
+      "line": 98,
+      "complexity": 5,
+      "line_coverage": 92.3076923076923,
+      "crap": 5.011379153390988
+    },
+    {
+      "package": "client",
+      "function": "(*otterCacheStore).Get",
+      "file": "internal/client/otter.go",
+      "line": 18,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "client",
+      "function": "(*otterCacheStore).Set",
+      "file": "internal/client/otter.go",
+      "line": 22,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "client",
+      "function": "(*otterCacheStore).Delete",
+      "file": "internal/client/otter.go",
+      "line": 27,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "client",
+      "function": "NewOtterStore",
+      "file": "internal/client/otter.go",
+      "line": 32,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "truthbeam",
+      "function": "newTruthBeamProcessor",
+      "file": "processor.go",
+      "line": 27,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "truthbeam",
+      "function": "(*truthBeamProcessor).processLogs",
+      "file": "processor.go",
+      "line": 42,
+      "complexity": 7,
+      "line_coverage": 95.23809523809524,
+      "crap": 7.005291005291006
+    },
+    {
+      "package": "truthbeam",
+      "function": "(*truthBeamProcessor).start",
+      "file": "processor.go",
+      "line": 84,
+      "complexity": 4,
+      "line_coverage": 72.72727272727273,
+      "crap": 4.324567993989482
+    }
+  ],
+  "summary": {
+    "total_functions": 22,
+    "avg_complexity": 3,
+    "avg_line_coverage": 87.75258832077014,
+    "avg_crap": 3.246459038780443,
+    "crapload": 0,
+    "crap_threshold": 15,
+    "gaze_crapload": 5,
+    "gaze_crap_threshold": 15,
+    "avg_gaze_crap": 21.11111111111111,
+    "avg_contract_coverage": 0,
+    "quadrant_counts": {
+      "Q1_Safe": 4,
+      "Q3_SimpleButUnderspecified": 5
+    },
+    "worst_crap": [
+      {
+        "package": "applier",
+        "function": "(*Applier).Extract",
+        "file": "internal/applier/applier.go",
+        "line": 68,
+        "complexity": 7,
+        "line_coverage": 90.47619047619048,
+        "crap": 7.042328042328042,
+        "contract_coverage": 0,
+        "gaze_crap": 56,
+        "quadrant": "Q3_SimpleButUnderspecified"
+      },
+      {
+        "package": "truthbeam",
+        "function": "(*truthBeamProcessor).processLogs",
+        "file": "processor.go",
+        "line": 42,
+        "complexity": 7,
+        "line_coverage": 95.23809523809524,
+        "crap": 7.005291005291006
+      },
+      {
+        "package": "applier",
+        "function": "(*Applier).Apply",
+        "file": "internal/applier/applier.go",
+        "line": 27,
+        "complexity": 7,
+        "line_coverage": 100,
+        "crap": 7,
+        "contract_coverage": 0,
+        "gaze_crap": 56,
+        "quadrant": "Q3_SimpleButUnderspecified"
+      },
+      {
+        "package": "truthbeam",
+        "function": "createLogsProcessor",
+        "file": "factory.go",
+        "line": 43,
+        "complexity": 2,
+        "line_coverage": 0,
+        "crap": 6
+      },
+      {
+        "package": "client",
+        "function": "(*CacheableClient).callEnrich",
+        "file": "internal/client/cacheable.go",
+        "line": 98,
+        "complexity": 5,
+        "line_coverage": 92.3076923076923,
+        "crap": 5.011379153390988
+      }
+    ],
+    "worst_gaze_crap": [
+      {
+        "package": "applier",
+        "function": "(*Applier).Apply",
+        "file": "internal/applier/applier.go",
+        "line": 27,
+        "complexity": 7,
+        "line_coverage": 100,
+        "crap": 7,
+        "contract_coverage": 0,
+        "gaze_crap": 56,
+        "quadrant": "Q3_SimpleButUnderspecified"
+      },
+      {
+        "package": "applier",
+        "function": "(*Applier).Extract",
+        "file": "internal/applier/applier.go",
+        "line": 68,
+        "complexity": 7,
+        "line_coverage": 90.47619047619048,
+        "crap": 7.042328042328042,
+        "contract_coverage": 0,
+        "gaze_crap": 56,
+        "quadrant": "Q3_SimpleButUnderspecified"
+      },
+      {
+        "package": "truthbeam",
+        "function": "(*Config).Validate",
+        "file": "config.go",
+        "line": 23,
+        "complexity": 5,
+        "line_coverage": 100,
+        "crap": 5,
+        "contract_coverage": 0,
+        "gaze_crap": 30,
+        "quadrant": "Q3_SimpleButUnderspecified"
+      },
+      {
+        "package": "client",
+        "function": "NewCacheableClient",
+        "file": "internal/client/cacheable.go",
+        "line": 30,
+        "complexity": 4,
+        "line_coverage": 87.5,
+        "crap": 4.03125,
+        "contract_coverage": 0,
+        "gaze_crap": 20,
+        "quadrant": "Q3_SimpleButUnderspecified"
+      },
+      {
+        "package": "client",
+        "function": "(*CacheableClient).Retrieve",
+        "file": "internal/client/cacheable.go",
+        "line": 64,
+        "complexity": 4,
+        "line_coverage": 92.3076923076923,
+        "crap": 4.007282658170232,
+        "contract_coverage": 0,
+        "gaze_crap": 20,
+        "quadrant": "Q3_SimpleButUnderspecified"
+      }
+    ]
+  }
+}

--- a/truthbeam/.gaze/baseline.json
+++ b/truthbeam/.gaze/baseline.json
@@ -8,9 +8,9 @@
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5,
-      "contract_coverage": 0,
-      "gaze_crap": 30,
-      "quadrant": "Q3_SimpleButUnderspecified"
+      "contract_coverage": 33.333333333333336,
+      "gaze_crap": 12.407407407407405,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "truthbeam",
@@ -20,8 +20,8 @@
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
       "quadrant": "Q1_Safe"
     },
     {
@@ -50,8 +50,8 @@
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
       "quadrant": "Q1_Safe"
     },
     {
@@ -62,9 +62,9 @@
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7,
-      "contract_coverage": 0,
-      "gaze_crap": 56,
-      "quadrant": "Q3_SimpleButUnderspecified"
+      "contract_coverage": 100,
+      "gaze_crap": 7,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "applier",
@@ -74,9 +74,9 @@
       "complexity": 7,
       "line_coverage": 90.47619047619048,
       "crap": 7.042328042328042,
-      "contract_coverage": 0,
-      "gaze_crap": 56,
-      "quadrant": "Q3_SimpleButUnderspecified"
+      "contract_coverage": 100,
+      "gaze_crap": 7,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "applier",
@@ -113,9 +113,9 @@
       "complexity": 4,
       "line_coverage": 87.5,
       "crap": 4.03125,
-      "contract_coverage": 0,
-      "gaze_crap": 20,
-      "quadrant": "Q3_SimpleButUnderspecified"
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "client",
@@ -125,8 +125,8 @@
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
       "quadrant": "Q1_Safe"
     },
     {
@@ -146,9 +146,9 @@
       "complexity": 4,
       "line_coverage": 92.3076923076923,
       "crap": 4.007282658170232,
-      "contract_coverage": 0,
-      "gaze_crap": 20,
-      "quadrant": "Q3_SimpleButUnderspecified"
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "client",
@@ -194,8 +194,8 @@
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
       "quadrant": "Q1_Safe"
     },
     {
@@ -233,13 +233,12 @@
     "avg_crap": 3.246459038780443,
     "crapload": 0,
     "crap_threshold": 15,
-    "gaze_crapload": 5,
+    "gaze_crapload": 0,
     "gaze_crap_threshold": 15,
-    "avg_gaze_crap": 21.11111111111111,
-    "avg_contract_coverage": 0,
+    "avg_gaze_crap": 4.267489711934156,
+    "avg_contract_coverage": 92.5925925925926,
     "quadrant_counts": {
-      "Q1_Safe": 4,
-      "Q3_SimpleButUnderspecified": 5
+      "Q1_Safe": 9
     },
     "worst_crap": [
       {
@@ -250,9 +249,9 @@
         "complexity": 7,
         "line_coverage": 90.47619047619048,
         "crap": 7.042328042328042,
-        "contract_coverage": 0,
-        "gaze_crap": 56,
-        "quadrant": "Q3_SimpleButUnderspecified"
+        "contract_coverage": 100,
+        "gaze_crap": 7,
+        "quadrant": "Q1_Safe"
       },
       {
         "package": "truthbeam",
@@ -271,9 +270,9 @@
         "complexity": 7,
         "line_coverage": 100,
         "crap": 7,
-        "contract_coverage": 0,
-        "gaze_crap": 56,
-        "quadrant": "Q3_SimpleButUnderspecified"
+        "contract_coverage": 100,
+        "gaze_crap": 7,
+        "quadrant": "Q1_Safe"
       },
       {
         "package": "truthbeam",
@@ -296,6 +295,18 @@
     ],
     "worst_gaze_crap": [
       {
+        "package": "truthbeam",
+        "function": "(*Config).Validate",
+        "file": "config.go",
+        "line": 23,
+        "complexity": 5,
+        "line_coverage": 100,
+        "crap": 5,
+        "contract_coverage": 33.333333333333336,
+        "gaze_crap": 12.407407407407405,
+        "quadrant": "Q1_Safe"
+      },
+      {
         "package": "applier",
         "function": "(*Applier).Apply",
         "file": "internal/applier/applier.go",
@@ -303,9 +314,9 @@
         "complexity": 7,
         "line_coverage": 100,
         "crap": 7,
-        "contract_coverage": 0,
-        "gaze_crap": 56,
-        "quadrant": "Q3_SimpleButUnderspecified"
+        "contract_coverage": 100,
+        "gaze_crap": 7,
+        "quadrant": "Q1_Safe"
       },
       {
         "package": "applier",
@@ -315,21 +326,9 @@
         "complexity": 7,
         "line_coverage": 90.47619047619048,
         "crap": 7.042328042328042,
-        "contract_coverage": 0,
-        "gaze_crap": 56,
-        "quadrant": "Q3_SimpleButUnderspecified"
-      },
-      {
-        "package": "truthbeam",
-        "function": "(*Config).Validate",
-        "file": "config.go",
-        "line": 23,
-        "complexity": 5,
-        "line_coverage": 100,
-        "crap": 5,
-        "contract_coverage": 0,
-        "gaze_crap": 30,
-        "quadrant": "Q3_SimpleButUnderspecified"
+        "contract_coverage": 100,
+        "gaze_crap": 7,
+        "quadrant": "Q1_Safe"
       },
       {
         "package": "client",
@@ -339,9 +338,9 @@
         "complexity": 4,
         "line_coverage": 87.5,
         "crap": 4.03125,
-        "contract_coverage": 0,
-        "gaze_crap": 20,
-        "quadrant": "Q3_SimpleButUnderspecified"
+        "contract_coverage": 100,
+        "gaze_crap": 4,
+        "quadrant": "Q1_Safe"
       },
       {
         "package": "client",
@@ -351,9 +350,9 @@
         "complexity": 4,
         "line_coverage": 92.3076923076923,
         "crap": 4.007282658170232,
-        "contract_coverage": 0,
-        "gaze_crap": 20,
-        "quadrant": "Q3_SimpleButUnderspecified"
+        "contract_coverage": 100,
+        "gaze_crap": 4,
+        "quadrant": "Q1_Safe"
       }
     ]
   }


### PR DESCRIPTION
## Summary

Add CRAP load monitoring Makefile targets adapted for the multi-module monorepo structure, consistent with the complyctl implementation. Initial per-module baselines are generated for `proofwatch` and `truthbeam`.

The new targets use [gaze](https://github.com/unbound-force/gaze) to compute CRAP (Change Risk Anti-Patterns) and GazeCRAP scores per function, based on cyclomatic complexity and test coverage.
The baselines capture current scores so that future PRs can be checked for regressions via `make crapload-check`.

Targets added:
  - `ensure-gaze` — installs gaze if not already present
  - `crapload` — human-readable CRAP analysis for all modules
  - `crapload-baseline` — generates `<module>/.gaze/baseline.json` per module
  - `crapload-check` — fails if any function in any module regresses beyond the baseline or if a new function exceeds the threshold (default CRAP > 30)

## Related Issues

- Part of the effort to standardize CRAP load analysis across complytime repositories (consistent with complyctl)
- https://redhat.atlassian.net/browse/CPLYTM-1376

## Review Hints

- The Makefile diff is self-contained — all new targets are in the `CRAP Load Monitoring` section, right before `Help Target`.

- Since this repo uses `go.work` referencing a `../compass` module that may not be present locally, run with `GOWORK=off`:

```bash
export GOWORK=off

# 1. Install gaze (one-time)
make ensure-gaze

# 2. Run human-readable analysis for all modules
make crapload

# 3. Regenerate baselines (already committed, but you can verify)
make crapload-baseline
cat proofwatch/.gaze/baseline.json | jq '.summary'
cat truthbeam/.gaze/baseline.json | jq '.summary'

# 4. Check for regressions against the committed baselines (should PASS)
make crapload-check
```

- To simulate a regression, temporarily lower the threshold and re-check:
```bash
make crapload-check GAZE_NEW_FUNC_THRESHOLD=1
```