### PR TITLE
feat: simplify gemara otel mapping

### DIFF
--- a/openspec/changes/simplify-oci-enrichment/.openspec.yaml
+++ b/openspec/changes/simplify-oci-enrichment/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-20
+title: "Drop OCSF, truthbeam, and Compass; proofwatch owns Gemara-to-OTel mapping"
+status: draft

--- a/openspec/changes/simplify-oci-enrichment/.openspec.yaml
+++ b/openspec/changes/simplify-oci-enrichment/.openspec.yaml
@@ -1,4 +1,4 @@
 schema: spec-driven
 created: 2026-04-20
-title: "Drop OCSF, truthbeam, and Compass; proofwatch owns Gemara-to-OTel mapping"
+title: "Drop OCSF, truthbeam, and Compass; rename to complytime-collector-components; proofwatch owns Gemara-to-OTel mapping"
 status: draft

--- a/openspec/changes/simplify-oci-enrichment/design.md
+++ b/openspec/changes/simplify-oci-enrichment/design.md
@@ -13,45 +13,34 @@ Proofwatch emits flat `GemaraEvidence` records (an `AssessmentLog` + `Metadata`)
 
 Compass is a stateless HTTP wrapper around a Gemara catalog YAML file. The four fields it adds (`category`, `frameworks`, `requirements`, `risk.level`) are static catalog reference data. `compliance.status` is a pure function of `Result`.
 
-Meanwhile, complyctl already produces full `gemara.EvaluationLog` objects with the complete hierarchy:
+### Evidence model: GemaraEvidence is the right abstraction
 
-```
-EvaluationLog
-  ├── Metadata (Author/Actor, Id)
-  ├── Target (Resource: Name, Id, Type, Environment)
-  └── Evaluations[]
-        ├── Control (EntryMapping: EntryId, ReferenceId)
-        └── AssessmentLogs[]
-              ├── Requirement (EntryMapping)
-              ├── Plan (*EntryMapping, optional)
-              ├── Result, Message, Recommendation
-              └── Applicability, ConfidenceLevel, Start/End
-```
+complyctl plugins operate at the **AssessmentLog + Metadata** level. They do not have access to the full `EvaluationLog` hierarchy (`Target`, `ControlEvaluation` parent context). An `EvaluationLog` fan-out at the proofwatch layer was considered and rejected for three reasons:
 
-This hierarchy carries every field needed for complete OTel semantic convention mapping. The `Target` and `Control` context on the outer objects propagate naturally to each `AssessmentLog`. There is no data that requires a runtime catalog lookup -- everything is available at the point of evidence emission.
+1. **Plugin scope**: Plugins produce individual assessment records, not full evaluation hierarchies. The `GemaraEvidence` type (flat: `Metadata` + `AssessmentLog`) matches what producers actually have.
+2. **Target reliability**: complyctl merges multiple targets into a single `EvaluationLog` with a zero-value `Target` field. The hierarchy is not reliable for per-target attribution today.
+3. **Simplicity**: Adding `compliance.status` to `GemaraEvidence.Attributes()` is a one-line change. A fan-out adds a new type, new tests, and a new API surface for no gain given the current producer constraints.
+
+If complyctl evolves to produce per-target `EvaluationLog` objects with populated `Target` fields, a fan-out API can be added later as an additional capability.
 
 ### Data mapping analysis
 
-**Fields available from Gemara EvaluationLog hierarchy (no external lookup):**
+**Fields available from GemaraEvidence (no external lookup):**
 
 | Source | Gemara Field | OTel Attribute |
 |:--|:--|:--|
-| EvaluationLog | `Target.Name` | `policy.target.name` |
-| EvaluationLog | `Target.Id` | `policy.target.id` |
-| EvaluationLog | `Target.Type` | `policy.target.type` |
-| EvaluationLog | `Target.Environment` | `policy.target.environment` |
-| EvaluationLog | `Metadata.Author.Name` | `policy.engine.name` |
-| EvaluationLog | `Metadata.Author.Version` | `policy.engine.version` |
-| EvaluationLog | `Metadata.Author.Uri` | `policy.rule.uri` |
-| EvaluationLog | `Metadata.Id` | `compliance.assessment.id` |
-| ControlEvaluation | `Control.EntryId` | `compliance.control.id` |
-| ControlEvaluation | `Control.ReferenceId` | `compliance.control.catalog.id` |
+| Metadata | `Author.Name` | `policy.engine.name` |
+| Metadata | `Author.Version` | `policy.engine.version` |
+| Metadata | `Author.Uri` | `policy.rule.uri` |
+| Metadata | `Id` | `compliance.assessment.id` |
+| AssessmentLog | `Requirement.EntryId` | `compliance.control.id` |
+| AssessmentLog | `Requirement.ReferenceId` | `compliance.control.catalog.id` |
 | AssessmentLog | `Result` | `policy.evaluation.result` |
 | AssessmentLog | `Plan.EntryId` | `policy.rule.id` (opt_in, nil-guarded) |
 | AssessmentLog | `Message` | `policy.evaluation.message` |
 | AssessmentLog | `Recommendation` | `compliance.remediation.description` |
 | AssessmentLog | `Applicability` | `compliance.control.applicability` |
-| *(derived)* | `mapResult(Result)` | `compliance.status` |
+| *(derived)* | `MapResult(Result)` | `compliance.status` |
 
 **Fields that required Compass (catalog-only, no longer populated):**
 
@@ -63,17 +52,20 @@ This hierarchy carries every field needed for complete OTel semantic convention 
 | `Risk.Level` | `compliance.risk.level` | Deferred to query-time enrichment |
 | `EnrichmentStatus` | `compliance.enrichment.status` | Removed |
 
-Every attribute that matters for auditor workflows (control ID, catalog ID, target name, pass/fail status) is available from the Gemara hierarchy. The catalog-derived cross-references are reference data suitable for query-time joins.
+Every attribute that matters for auditor workflows (control ID, catalog ID, pass/fail status) is available from `GemaraEvidence`. The catalog-derived cross-references are reference data suitable for query-time joins.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Proofwatch accepts `gemara.EvaluationLog` and fans out to one OTel log record per `AssessmentLog` with full semantic convention attributes
+- Proofwatch emits `compliance.status` on every `GemaraEvidence` log record via local `MapResult()` derivation
 - Remove truthbeam processor, OCSF support, Compass service, and cert infrastructure
+- Rename all internal references from `complybeacon`/`beacon` to `complytime-collector-components`/`complytime`
 - Collector retains custom OCB distro (non-standard components) but drops all custom processor code
+- Add ClickHouse exporter to distro manifest
 - Maintain fail-open behavior (malformed records pass through with warning)
 
 **Non-Goals:**
+- `EvaluationLog` fan-out in proofwatch (producers don't have that context today)
 - Adding new Gemara fields or modifying the `go-gemara` SDK
 - Query-time catalog enrichment tooling (future work)
 - Changing complyctl's `EvaluationLog` generation (upstream dependency, tracked separately)
@@ -81,44 +73,50 @@ Every attribute that matters for auditor workflows (control ID, catalog ID, targ
 
 ## Decisions
 
-### 1. Proofwatch owns the Gemara-to-OTel mapping
+### 1. Proofwatch adds compliance.status to GemaraEvidence
 
-Move all semantic convention attribute mapping to proofwatch. The `EvaluationLog` fan-out works as follows:
+Add `MapResult()` to proofwatch (ported from `truthbeam/internal/applier/status.go`) and call it in `GemaraEvidence.Attributes()`. This is a single new attribute on an existing type -- no new types, no new API surface.
 
-For each `ControlEvaluation` in `EvaluationLog.Evaluations`:
-  For each `AssessmentLog` in `ControlEvaluation.AssessmentLogs`:
-    Emit one OTel log record with:
-    - `Target` attributes from `EvaluationLog.Target`
-    - `Control` attributes from `ControlEvaluation.Control`
-    - Assessment attributes from the `AssessmentLog` itself
-    - `compliance.status` derived from `AssessmentLog.Result`
+The `MapResult()` function maps:
+- `Passed` → `Compliant`
+- `Failed` → `Non-Compliant`
+- `NotApplicable`, `NotRun` → `Not Applicable`
+- default → `Unknown`
 
-This replaces the current `GemaraEvidence` type (flat struct) with a richer input that preserves the full hierarchy context.
+Lives in `proofwatch/status.go` as an exported function with an exported `ComplianceStatus` type.
 
 **Alternatives considered:**
-- *Keep truthbeam as mapper, proofwatch does fan-out only*: proofwatch would emit records with Gemara fields as raw attributes, truthbeam would rename them to semantic conventions. Rejected -- adds a pass-through processor for pure field renaming that proofwatch can do at the source.
-- *Fan out in a collector processor instead of proofwatch*: Would require truthbeam to parse structured Gemara JSON from log bodies. Rejected -- moves complexity into the pipeline that belongs at the evidence producer.
+- *EvaluationLog fan-out*: Rejected. complyctl plugins only produce AssessmentLog + Metadata. The full hierarchy is not available to evidence producers. If this changes upstream, a fan-out can be added as an additional capability without breaking the flat API.
+- *Keep truthbeam for status derivation only*: Rejected. A custom collector processor for one `switch` statement is not justified.
 
 ### 2. Delete truthbeam entirely
 
-With proofwatch emitting fully-mapped records, truthbeam has zero remaining function. A pass-through processor adds build complexity (custom collector distro), config surface, and a test surface for no value.
+With proofwatch emitting `compliance.status` directly, truthbeam has zero remaining function. The collector remains a custom OCB-built distro (non-standard receivers, exporters, and extensions are still needed), but the manifest drops the truthbeam module.
 
-The collector remains a custom OCB-built distro (non-standard receivers, exporters, and extensions are still needed), but `beacon-distro/manifest.yaml` drops the truthbeam module. No custom Go processor code runs in the pipeline.
+### 3. Retain GemaraEvidence as the primary evidence type
 
-**Alternatives considered:**
-- *Keep truthbeam as optional enrichment processor for future Path B*: Would require maintaining the module, tests, and custom distro build even when unused. Rejected -- if Path B is needed later, it can be re-added. Dead code has carrying cost.
+The existing `GemaraEvidence` struct (explicit `Metadata` field + embedded `AssessmentLog`) is the right level of abstraction. It now emits `compliance.status` in addition to its existing attributes. The `validate-logs` CLI uses it directly for semantic convention validation.
 
-### 3. Port `mapResult()` to proofwatch
+### 4. Remove OCSF, Compass, and cert infrastructure
 
-The `Result` → `compliance.status` mapping logic (`Passed` → `Compliant`, `Failed` → `Non-Compliant`, etc.) currently lives in `truthbeam/internal/applier/status.go`. Port this function to proofwatch where it will be used during the fan-out.
+No migration path needed. No consumers. Clean delete.
 
-### 4. Retain `GemaraEvidence` for backward compatibility
+**Implementation detail**: `proofwatch/proofwatch_test.go` shares a `createTestEvidence()` helper defined in `ocsf_test.go`. This must be replaced with `createTestGemaraEvidence()` (from `gemara_test.go`) before deleting OCSF test files.
 
-Keep the existing `GemaraEvidence` type and its `Attributes()` method for callers that produce individual assessment records (not full EvaluationLogs). The new `EvaluationLog` fan-out is an additional capability, not a replacement. `cmd/validate-logs` uses `GemaraEvidence` directly for semantic convention validation.
+### 5. Rename from complybeacon to complytime-collector-components
 
-### 5. Remove OCSF, Compass, and cert infrastructure
+The GitHub repo was renamed. All internal references update:
 
-No migration path. No consumers. Clean delete.
+| Old | New |
+|:--|:--|
+| `github.com/complytime/complybeacon/proofwatch` | `github.com/complytime/complytime-collector-components/proofwatch` |
+| `beacon-distro/` | `collector-distro/` |
+| `otelcol-beacon` | `otelcol-complytime` |
+| `complybeacon-beacon-distro` (image) | `complytime-collector-distro` (image) |
+| `beacon.evidence` (entity) | `complytime.evidence` |
+| `ComplyBeacon` (prose) | `ComplyTime Collector` |
+
+This touches Go module paths, ScopeName constants, imports, CI workflow job names, image names (GHCR + Quay), Containerfile labels, compose context paths, dependabot config, sonar config, and all docs.
 
 ### 6. Collector pipeline simplification
 
@@ -138,82 +136,45 @@ logs:
   exporters: [debug]
 ```
 
-### 7. Upstream dependency: complyctl Target population
+### 7. Add ClickHouse exporter
 
-complyctl's `Evaluator.GemaraLog()` currently returns `EvaluationLog` with a zero-value `Target` field. For the fan-out to produce useful `policy.target.*` attributes, complyctl must populate `Target` with the scanned repository's `Resource` data. This is tracked as an upstream dependency, not blocked by this change -- proofwatch handles a zero-value `Target` gracefully by omitting `policy.target.*` attributes.
+Add `clickhouseexporter` to the OCB manifest at the same version as other contrib components (`v0.144.0`). Enables direct log export to ClickHouse for analytics and long-term storage.
+
+### 8. validate-logs CLI simplification
+
+Before: accepts `gemara|ocsf|both` format argument, simulates truthbeam enrichment.
+After: no format argument (Gemara-only), no enrichment simulation, simplified main function.
 
 ## Open Decisions
 
-### 8. Attribute namespace: keep policy/compliance dichotomy or unify under Gemara-native naming?
+### 9. Attribute namespace: keep policy/compliance dichotomy or unify under Gemara-native naming?
 
 The current attribute model splits into two namespaces:
 - `policy.*` -- engine, rule, evaluation result, target
 - `compliance.*` -- control, catalog, status, remediation, assessment ID
 
-This split originated from the old architecture where `policy.*` attributes came from the evidence producer and `compliance.*` attributes were added by Compass enrichment. With enrichment removed and all data sourced from a single Gemara `EvaluationLog`, the boundary is an artifact of the pipeline, not the data model.
+This split originated from the old architecture where `policy.*` attributes came from the evidence producer and `compliance.*` attributes were added by Compass enrichment. With enrichment removed and all data sourced from `GemaraEvidence`, the boundary is an artifact of the pipeline, not the data model.
 
 Examples of the mismatch:
 
 | Observation | Issue |
 |:--|:--|
-| `AssessmentLog.Result` → `policy.evaluation.result` but `mapResult(Result)` → `compliance.status` | Same field, two namespaces |
+| `AssessmentLog.Result` → `policy.evaluation.result` but `MapResult(Result)` → `compliance.status` | Same field, two namespaces |
 | `Metadata.Id` → `compliance.assessment.id` but `Metadata.Author.Name` → `policy.engine.name` | Same parent struct, two namespaces |
-| `Control.EntryId` → `compliance.control.id` but `Target.Name` → `policy.target.name` | Parallel Gemara concepts, different namespaces |
 
-**Option A: Keep the dichotomy**
+**Option A: Keep the dichotomy** -- No breaking change. `policy` and `compliance` are arguably two semantic domains. Aligns with OTel domain-based namespacing.
 
-- No breaking change to existing configs, queries, dashboards
-- `policy` and `compliance` are arguably two semantic domains even if the data source is one
-- Aligns with OTel convention of domain-based namespacing (`http.*`, `db.*`, `rpc.*`)
-- Cost: new contributors must learn an arbitrary split that doesn't match the Gemara type hierarchy
+**Option B: Unify under Gemara-native namespace** (`gemara.*`) -- Mirrors SDK hierarchy. Breaking change to all queries/dashboards.
 
-**Option B: Unify under Gemara-native namespace**
+**Option C: Hybrid domain-generic** (`assessment.*`, `control.*`, `target.*`) -- Follows data model, not pipeline. Still a breaking change.
 
-Example mapping:
-
-| Gemara Source | Attribute |
-|:--|:--|
-| `EvaluationLog.Metadata.Author.Name` | `gemara.author.name` |
-| `EvaluationLog.Metadata.Id` | `gemara.evaluation.id` |
-| `EvaluationLog.Target.Name` | `gemara.target.name` |
-| `ControlEvaluation.Control.EntryId` | `gemara.control.id` |
-| `ControlEvaluation.Control.ReferenceId` | `gemara.control.catalog_id` |
-| `AssessmentLog.Result` | `gemara.assessment.result` |
-| `AssessmentLog.Plan.EntryId` | `gemara.plan.id` |
-| `AssessmentLog.Message` | `gemara.assessment.message` |
-| `AssessmentLog.Recommendation` | `gemara.assessment.recommendation` |
-| `AssessmentLog.Applicability` | `gemara.assessment.applicability` |
-| *(derived)* | `gemara.assessment.status` |
-
-- Attribute names mirror the Gemara SDK type hierarchy directly
-- Single namespace, simpler mental model
-- Eliminates the artificial policy/compliance boundary
-- Cost: breaks every existing query, config, and dashboard that references `policy.*` or `compliance.*`
-- Cost: `gemara.*` namespace is project-specific, not domain-generic -- may limit adoption by tools that don't use Gemara
-
-**Option C: Hybrid -- domain namespace, Gemara-aligned structure**
-
-Keep domain-generic names (`assessment.*`, `control.*`, `target.*`) but restructure to follow the Gemara hierarchy rather than the old pipeline boundary:
-
-| Gemara Source | Attribute |
-|:--|:--|
-| `EvaluationLog.Metadata.Author.Name` | `assessment.engine.name` |
-| `EvaluationLog.Metadata.Id` | `assessment.id` |
-| `EvaluationLog.Target.Name` | `target.name` |
-| `ControlEvaluation.Control.EntryId` | `control.id` |
-| `AssessmentLog.Result` | `assessment.result` |
-| `AssessmentLog.Plan.EntryId` | `assessment.plan.id` |
-| *(derived)* | `assessment.status` |
-
-- Domain-generic (not Gemara-specific), could be adopted by non-Gemara tools
-- Follows the data model, not the pipeline
-- Still a breaking change to existing configs
-
-**Status:** Open for discussion. This decision affects the attribute model (`model/attributes.yaml`), all generated docs, proofwatch's attribute constants, and any downstream query or dashboard. Should be resolved before implementation begins.
+**Status:** Open for discussion. The implementation proceeds with the existing dichotomy (Option A) since `proofwatch/attributes.go` constants are centralized and easily changed.
 
 ## Risks / Trade-offs
 
-- **[Catalog-derived attributes dropped]** → `compliance.control.category`, `compliance.frameworks`, `compliance.requirements`, `compliance.risk.level` no longer populated. No known consumers. If needed, query-time enrichment is the appropriate pattern for static reference data.
-- **[Custom distro still needed]** → Even without truthbeam, the collector distro may include non-standard receivers/exporters (webhook, S3, signaltometrics). The custom build remains, but with no custom processor code.
-- **[complyctl Target not populated]** → Until complyctl is updated, `policy.target.*` attributes will be absent. Fan-out still works -- records just lack target context. Proofwatch does not fail on zero-value Target.
-- **[Two evidence APIs in proofwatch]** → `GemaraEvidence` (flat) and `EvaluationLog` fan-out (hierarchical) coexist. This is intentional -- different callers have different needs. The flat API remains useful for simple single-assessment evidence and for `cmd/validate-logs`.
+- **[Catalog-derived attributes dropped]** → No known consumers. Query-time enrichment is the appropriate pattern for static reference data.
+- **[Custom distro still needed]** → Non-standard receivers/exporters (webhook, S3, ClickHouse, signaltometrics). Custom build remains, but with no custom processor code.
+- **[Two evidence APIs not needed]** → The original spec proposed `GemaraEvidence` (flat) + `EvaluationLog` fan-out (hierarchical). Implementation showed only the flat API is needed given current producer constraints. Scope reduced.
+- **[Test helper dependency]** → `proofwatch_test.go` uses `createTestEvidence()` from `ocsf_test.go`. Must replace with `createTestGemaraEvidence()` before deleting OCSF files.
+- **[Vendor directory staleness]** → After removing `go-ocsf`, the vendor directory is stale. Use `-mod=readonly` for builds/tests, or run `go mod vendor` to sync.
+- **[Entity rename]** → `beacon.evidence` → `complytime.evidence` in `model/entities.yaml`. No external consumers of this entity ID.

--- a/openspec/changes/simplify-oci-enrichment/design.md
+++ b/openspec/changes/simplify-oci-enrichment/design.md
@@ -1,0 +1,219 @@
+## Context
+
+ComplyBeacon's current architecture has four runtime components in the log pipeline:
+
+```
+proofwatch (client lib) → OTLP → collector:
+  transform/ocsf → truthbeam → [exporters]
+                       ↓
+              compass (HTTP, mTLS)
+```
+
+Proofwatch emits flat `GemaraEvidence` records (an `AssessmentLog` + `Metadata`) with a subset of OTel semantic convention attributes. The collector's `transform/ocsf` processor handles OCSF-format logs (no consumers exist). Truthbeam extracts `policy.*` attributes, calls Compass for compliance enrichment, and writes `compliance.*` attributes back.
+
+Compass is a stateless HTTP wrapper around a Gemara catalog YAML file. The four fields it adds (`category`, `frameworks`, `requirements`, `risk.level`) are static catalog reference data. `compliance.status` is a pure function of `Result`.
+
+Meanwhile, complyctl already produces full `gemara.EvaluationLog` objects with the complete hierarchy:
+
+```
+EvaluationLog
+  ├── Metadata (Author/Actor, Id)
+  ├── Target (Resource: Name, Id, Type, Environment)
+  └── Evaluations[]
+        ├── Control (EntryMapping: EntryId, ReferenceId)
+        └── AssessmentLogs[]
+              ├── Requirement (EntryMapping)
+              ├── Plan (*EntryMapping, optional)
+              ├── Result, Message, Recommendation
+              └── Applicability, ConfidenceLevel, Start/End
+```
+
+This hierarchy carries every field needed for complete OTel semantic convention mapping. The `Target` and `Control` context on the outer objects propagate naturally to each `AssessmentLog`. There is no data that requires a runtime catalog lookup -- everything is available at the point of evidence emission.
+
+### Data mapping analysis
+
+**Fields available from Gemara EvaluationLog hierarchy (no external lookup):**
+
+| Source | Gemara Field | OTel Attribute |
+|:--|:--|:--|
+| EvaluationLog | `Target.Name` | `policy.target.name` |
+| EvaluationLog | `Target.Id` | `policy.target.id` |
+| EvaluationLog | `Target.Type` | `policy.target.type` |
+| EvaluationLog | `Target.Environment` | `policy.target.environment` |
+| EvaluationLog | `Metadata.Author.Name` | `policy.engine.name` |
+| EvaluationLog | `Metadata.Author.Version` | `policy.engine.version` |
+| EvaluationLog | `Metadata.Author.Uri` | `policy.rule.uri` |
+| EvaluationLog | `Metadata.Id` | `compliance.assessment.id` |
+| ControlEvaluation | `Control.EntryId` | `compliance.control.id` |
+| ControlEvaluation | `Control.ReferenceId` | `compliance.control.catalog.id` |
+| AssessmentLog | `Result` | `policy.evaluation.result` |
+| AssessmentLog | `Plan.EntryId` | `policy.rule.id` (opt_in, nil-guarded) |
+| AssessmentLog | `Message` | `policy.evaluation.message` |
+| AssessmentLog | `Recommendation` | `compliance.remediation.description` |
+| AssessmentLog | `Applicability` | `compliance.control.applicability` |
+| *(derived)* | `mapResult(Result)` | `compliance.status` |
+
+**Fields that required Compass (catalog-only, no longer populated):**
+
+| Field | OTel Attribute | Disposition |
+|:--|:--|:--|
+| `Control.Category` | `compliance.control.category` | Deferred to query-time enrichment |
+| `Frameworks.Frameworks` | `compliance.frameworks` | Deferred to query-time enrichment |
+| `Frameworks.Requirements` | `compliance.requirements` | Deferred to query-time enrichment |
+| `Risk.Level` | `compliance.risk.level` | Deferred to query-time enrichment |
+| `EnrichmentStatus` | `compliance.enrichment.status` | Removed |
+
+Every attribute that matters for auditor workflows (control ID, catalog ID, target name, pass/fail status) is available from the Gemara hierarchy. The catalog-derived cross-references are reference data suitable for query-time joins.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Proofwatch accepts `gemara.EvaluationLog` and fans out to one OTel log record per `AssessmentLog` with full semantic convention attributes
+- Remove truthbeam processor, OCSF support, Compass service, and cert infrastructure
+- Collector retains custom OCB distro (non-standard components) but drops all custom processor code
+- Maintain fail-open behavior (malformed records pass through with warning)
+
+**Non-Goals:**
+- Adding new Gemara fields or modifying the `go-gemara` SDK
+- Query-time catalog enrichment tooling (future work)
+- Changing complyctl's `EvaluationLog` generation (upstream dependency, tracked separately)
+- Supporting non-Gemara evidence formats
+
+## Decisions
+
+### 1. Proofwatch owns the Gemara-to-OTel mapping
+
+Move all semantic convention attribute mapping to proofwatch. The `EvaluationLog` fan-out works as follows:
+
+For each `ControlEvaluation` in `EvaluationLog.Evaluations`:
+  For each `AssessmentLog` in `ControlEvaluation.AssessmentLogs`:
+    Emit one OTel log record with:
+    - `Target` attributes from `EvaluationLog.Target`
+    - `Control` attributes from `ControlEvaluation.Control`
+    - Assessment attributes from the `AssessmentLog` itself
+    - `compliance.status` derived from `AssessmentLog.Result`
+
+This replaces the current `GemaraEvidence` type (flat struct) with a richer input that preserves the full hierarchy context.
+
+**Alternatives considered:**
+- *Keep truthbeam as mapper, proofwatch does fan-out only*: proofwatch would emit records with Gemara fields as raw attributes, truthbeam would rename them to semantic conventions. Rejected -- adds a pass-through processor for pure field renaming that proofwatch can do at the source.
+- *Fan out in a collector processor instead of proofwatch*: Would require truthbeam to parse structured Gemara JSON from log bodies. Rejected -- moves complexity into the pipeline that belongs at the evidence producer.
+
+### 2. Delete truthbeam entirely
+
+With proofwatch emitting fully-mapped records, truthbeam has zero remaining function. A pass-through processor adds build complexity (custom collector distro), config surface, and a test surface for no value.
+
+The collector remains a custom OCB-built distro (non-standard receivers, exporters, and extensions are still needed), but `beacon-distro/manifest.yaml` drops the truthbeam module. No custom Go processor code runs in the pipeline.
+
+**Alternatives considered:**
+- *Keep truthbeam as optional enrichment processor for future Path B*: Would require maintaining the module, tests, and custom distro build even when unused. Rejected -- if Path B is needed later, it can be re-added. Dead code has carrying cost.
+
+### 3. Port `mapResult()` to proofwatch
+
+The `Result` → `compliance.status` mapping logic (`Passed` → `Compliant`, `Failed` → `Non-Compliant`, etc.) currently lives in `truthbeam/internal/applier/status.go`. Port this function to proofwatch where it will be used during the fan-out.
+
+### 4. Retain `GemaraEvidence` for backward compatibility
+
+Keep the existing `GemaraEvidence` type and its `Attributes()` method for callers that produce individual assessment records (not full EvaluationLogs). The new `EvaluationLog` fan-out is an additional capability, not a replacement. `cmd/validate-logs` uses `GemaraEvidence` directly for semantic convention validation.
+
+### 5. Remove OCSF, Compass, and cert infrastructure
+
+No migration path. No consumers. Clean delete.
+
+### 6. Collector pipeline simplification
+
+Before:
+```yaml
+logs:
+  receivers: [otlp]
+  processors: [batch, transform/ocsf, truthbeam]
+  exporters: [debug]
+```
+
+After:
+```yaml
+logs:
+  receivers: [otlp]
+  processors: [batch]
+  exporters: [debug]
+```
+
+### 7. Upstream dependency: complyctl Target population
+
+complyctl's `Evaluator.GemaraLog()` currently returns `EvaluationLog` with a zero-value `Target` field. For the fan-out to produce useful `policy.target.*` attributes, complyctl must populate `Target` with the scanned repository's `Resource` data. This is tracked as an upstream dependency, not blocked by this change -- proofwatch handles a zero-value `Target` gracefully by omitting `policy.target.*` attributes.
+
+## Open Decisions
+
+### 8. Attribute namespace: keep policy/compliance dichotomy or unify under Gemara-native naming?
+
+The current attribute model splits into two namespaces:
+- `policy.*` -- engine, rule, evaluation result, target
+- `compliance.*` -- control, catalog, status, remediation, assessment ID
+
+This split originated from the old architecture where `policy.*` attributes came from the evidence producer and `compliance.*` attributes were added by Compass enrichment. With enrichment removed and all data sourced from a single Gemara `EvaluationLog`, the boundary is an artifact of the pipeline, not the data model.
+
+Examples of the mismatch:
+
+| Observation | Issue |
+|:--|:--|
+| `AssessmentLog.Result` → `policy.evaluation.result` but `mapResult(Result)` → `compliance.status` | Same field, two namespaces |
+| `Metadata.Id` → `compliance.assessment.id` but `Metadata.Author.Name` → `policy.engine.name` | Same parent struct, two namespaces |
+| `Control.EntryId` → `compliance.control.id` but `Target.Name` → `policy.target.name` | Parallel Gemara concepts, different namespaces |
+
+**Option A: Keep the dichotomy**
+
+- No breaking change to existing configs, queries, dashboards
+- `policy` and `compliance` are arguably two semantic domains even if the data source is one
+- Aligns with OTel convention of domain-based namespacing (`http.*`, `db.*`, `rpc.*`)
+- Cost: new contributors must learn an arbitrary split that doesn't match the Gemara type hierarchy
+
+**Option B: Unify under Gemara-native namespace**
+
+Example mapping:
+
+| Gemara Source | Attribute |
+|:--|:--|
+| `EvaluationLog.Metadata.Author.Name` | `gemara.author.name` |
+| `EvaluationLog.Metadata.Id` | `gemara.evaluation.id` |
+| `EvaluationLog.Target.Name` | `gemara.target.name` |
+| `ControlEvaluation.Control.EntryId` | `gemara.control.id` |
+| `ControlEvaluation.Control.ReferenceId` | `gemara.control.catalog_id` |
+| `AssessmentLog.Result` | `gemara.assessment.result` |
+| `AssessmentLog.Plan.EntryId` | `gemara.plan.id` |
+| `AssessmentLog.Message` | `gemara.assessment.message` |
+| `AssessmentLog.Recommendation` | `gemara.assessment.recommendation` |
+| `AssessmentLog.Applicability` | `gemara.assessment.applicability` |
+| *(derived)* | `gemara.assessment.status` |
+
+- Attribute names mirror the Gemara SDK type hierarchy directly
+- Single namespace, simpler mental model
+- Eliminates the artificial policy/compliance boundary
+- Cost: breaks every existing query, config, and dashboard that references `policy.*` or `compliance.*`
+- Cost: `gemara.*` namespace is project-specific, not domain-generic -- may limit adoption by tools that don't use Gemara
+
+**Option C: Hybrid -- domain namespace, Gemara-aligned structure**
+
+Keep domain-generic names (`assessment.*`, `control.*`, `target.*`) but restructure to follow the Gemara hierarchy rather than the old pipeline boundary:
+
+| Gemara Source | Attribute |
+|:--|:--|
+| `EvaluationLog.Metadata.Author.Name` | `assessment.engine.name` |
+| `EvaluationLog.Metadata.Id` | `assessment.id` |
+| `EvaluationLog.Target.Name` | `target.name` |
+| `ControlEvaluation.Control.EntryId` | `control.id` |
+| `AssessmentLog.Result` | `assessment.result` |
+| `AssessmentLog.Plan.EntryId` | `assessment.plan.id` |
+| *(derived)* | `assessment.status` |
+
+- Domain-generic (not Gemara-specific), could be adopted by non-Gemara tools
+- Follows the data model, not the pipeline
+- Still a breaking change to existing configs
+
+**Status:** Open for discussion. This decision affects the attribute model (`model/attributes.yaml`), all generated docs, proofwatch's attribute constants, and any downstream query or dashboard. Should be resolved before implementation begins.
+
+## Risks / Trade-offs
+
+- **[Catalog-derived attributes dropped]** → `compliance.control.category`, `compliance.frameworks`, `compliance.requirements`, `compliance.risk.level` no longer populated. No known consumers. If needed, query-time enrichment is the appropriate pattern for static reference data.
+- **[Custom distro still needed]** → Even without truthbeam, the collector distro may include non-standard receivers/exporters (webhook, S3, signaltometrics). The custom build remains, but with no custom processor code.
+- **[complyctl Target not populated]** → Until complyctl is updated, `policy.target.*` attributes will be absent. Fan-out still works -- records just lack target context. Proofwatch does not fail on zero-value Target.
+- **[Two evidence APIs in proofwatch]** → `GemaraEvidence` (flat) and `EvaluationLog` fan-out (hierarchical) coexist. This is intentional -- different callers have different needs. The flat API remains useful for simple single-assessment evidence and for `cmd/validate-logs`.

--- a/openspec/changes/simplify-oci-enrichment/proposal.md
+++ b/openspec/changes/simplify-oci-enrichment/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+The repo has four layers of runtime complexity that exist to bridge a gap proofwatch can close at the source:
+
+1. **OCSF support** -- no downstream consumers. All evidence producers use Gemara. Dead code.
+2. **truthbeam processor** -- extracts `policy.*` attributes from log records, calls Compass for compliance enrichment, writes `compliance.*` attributes back. If proofwatch emits fully-mapped OTel log records directly from Gemara `EvaluationLog` types, truthbeam has nothing left to do.
+3. **Compass / gemara-content-service** -- HTTP service that maps `(engineName, ruleId)` to compliance metadata from a static catalog. The four fields it provides (`category`, `frameworks`, `requirements`, `risk.level`) are catalog reference data better joined at query time. `compliance.status` is derivable locally from `Result`. No runtime service needed.
+4. **mTLS cert infrastructure** -- exists solely to secure the truthbeam-to-compass link.
+
+The Gemara `EvaluationLog` type already carries all the data needed for complete OTel semantic convention mapping:
+- `EvaluationLog.Target` → `policy.target.*` attributes
+- `EvaluationLog.Metadata.Author` → `policy.engine.*` attributes
+- `ControlEvaluation.Control` → `compliance.control.*` attributes
+- `AssessmentLog.Result` → `policy.evaluation.result` + derived `compliance.status`
+- `AssessmentLog.Plan` → `policy.rule.id`
+- `AssessmentLog.Message` / `Recommendation` → `policy.evaluation.message` / `compliance.remediation.description`
+
+Proofwatch should accept an `EvaluationLog`, fan out to one OTel log record per `AssessmentLog`, propagate `Target` and `Control` context from parent objects, and emit fully-mapped semantic convention attributes. The collector becomes a stock distro: receive, batch, export.
+
+## What Changes
+
+**Remove:**
+- `truthbeam/` module (processor, applier, client, cache, codegen, config, factory, tests)
+- `proofwatch/ocsf.go`, `proofwatch/ocsf_test.go`, `go-ocsf` dependency
+- `transform/ocsf` processor from all collector configs
+- `compass` service from `compose.yaml`
+- Compass cert generation from `Makefile` and `hack/self-signed-cert/`
+- truthbeam from `beacon-distro/manifest.yaml` (OCB manifest)
+- All truthbeam config from collector configs
+
+**Add:**
+- `EvaluationLog` fan-out in proofwatch: accept `gemara.EvaluationLog`, walk `Evaluations[] → AssessmentLogs[]`, emit one OTel log record per assessment with inherited `Target` and `Control` context
+- `compliance.status` local derivation in proofwatch (port `mapResult()` from truthbeam `internal/applier/status.go`)
+- Full Gemara-to-OTel semantic convention attribute mapping in proofwatch
+
+**Update:**
+- `beacon-distro/manifest.yaml`: remove truthbeam module
+- `beacon-distro/config.yaml`: remove truthbeam and transform/ocsf processors; logs pipeline = `batch` only
+- `hack/demo/demo-config.yaml`: same pipeline simplification
+- `compose.yaml`: remove compass service, compass cert mounts, `depends_on`
+- `Makefile`: remove cert generation, update semantic check targets
+- `model/attributes.yaml`: remove `compliance.enrichment.status`; downgrade catalog-only attributes
+- Docs: `DESIGN.md`, `DEVELOPMENT.md`, `README.md`
+
+## Capabilities
+
+### New Capabilities
+
+- **EvaluationLog fan-out**: Proofwatch accepts a Gemara `EvaluationLog` and produces one OTel log record per `AssessmentLog`, with `Target` and `Control` context propagated from parent objects
+- **Self-contained attribute mapping**: Proofwatch maps all Gemara fields to OTel semantic conventions at the source, including local `compliance.status` derivation
+
+### Removed Capabilities
+
+- **In-pipeline enrichment**: truthbeam's `Extract → Enrich → Apply` pipeline removed entirely
+- **Catalog-derived attributes**: `compliance.control.category`, `compliance.frameworks`, `compliance.requirements`, `compliance.risk.level` no longer populated at pipeline time. Deferred to query-time enrichment if needed.
+- **`compliance.enrichment.status`**: Removed -- no enrichment, no enrichment status
+- **OCSF evidence format**: Removed -- no consumers
+
+## Impact
+
+- **proofwatch module**: New `EvaluationLog` fan-out capability; `ocsf.go` deleted; `go-ocsf` dropped; `mapResult()` ported from truthbeam
+- **truthbeam module**: Deleted entirely
+- **beacon-distro**: `manifest.yaml` removes truthbeam module; custom distro retained for non-standard receivers/exporters/extensions but carries no custom processor code
+- **Deployment**: Single collector container, no sidecar. No mTLS. `docker compose up` starts loki + grafana + collector only.
+- **Attribute model**: `compliance.enrichment.status` removed; four catalog-derived attributes downgraded
+- **Upstream dependency**: complyctl must populate `EvaluationLog.Target` (currently zero-valued in `evaluator.go` `GemaraLog()`)
+- **No downstream impact**: No external OCSF consumers; no known consumers of catalog-derived attributes

--- a/openspec/changes/simplify-oci-enrichment/proposal.md
+++ b/openspec/changes/simplify-oci-enrichment/proposal.md
@@ -3,19 +3,21 @@
 The repo has four layers of runtime complexity that exist to bridge a gap proofwatch can close at the source:
 
 1. **OCSF support** -- no downstream consumers. All evidence producers use Gemara. Dead code.
-2. **truthbeam processor** -- extracts `policy.*` attributes from log records, calls Compass for compliance enrichment, writes `compliance.*` attributes back. If proofwatch emits fully-mapped OTel log records directly from Gemara `EvaluationLog` types, truthbeam has nothing left to do.
+2. **truthbeam processor** -- extracts `policy.*` attributes from log records, calls Compass for compliance enrichment, writes `compliance.*` attributes back. If proofwatch emits fully-mapped OTel log records directly from Gemara types, truthbeam has nothing left to do.
 3. **Compass / gemara-content-service** -- HTTP service that maps `(engineName, ruleId)` to compliance metadata from a static catalog. The four fields it provides (`category`, `frameworks`, `requirements`, `risk.level`) are catalog reference data better joined at query time. `compliance.status` is derivable locally from `Result`. No runtime service needed.
 4. **mTLS cert infrastructure** -- exists solely to secure the truthbeam-to-compass link.
 
-The Gemara `EvaluationLog` type already carries all the data needed for complete OTel semantic convention mapping:
-- `EvaluationLog.Target` → `policy.target.*` attributes
-- `EvaluationLog.Metadata.Author` → `policy.engine.*` attributes
-- `ControlEvaluation.Control` → `compliance.control.*` attributes
-- `AssessmentLog.Result` → `policy.evaluation.result` + derived `compliance.status`
-- `AssessmentLog.Plan` → `policy.rule.id`
-- `AssessmentLog.Message` / `Recommendation` → `policy.evaluation.message` / `compliance.remediation.description`
+Additionally, the repository was renamed to `complytime-collector-components` but internal references still use `complybeacon` / `beacon`.
 
-Proofwatch should accept an `EvaluationLog`, fan out to one OTel log record per `AssessmentLog`, propagate `Target` and `Control` context from parent objects, and emit fully-mapped semantic convention attributes. The collector becomes a stock distro: receive, batch, export.
+### Evidence model insight
+
+complyctl plugins operate at the **AssessmentLog + Metadata** level, not the full `EvaluationLog` hierarchy. Plugins do not have access to `Target` or `ControlEvaluation` parent context. The existing `GemaraEvidence` type (flat struct: `Metadata` + `AssessmentLog`) is the correct abstraction for evidence emission. An `EvaluationLog` fan-out is not appropriate at the proofwatch layer because:
+
+- Plugins produce individual assessment records, not full evaluation hierarchies
+- The `Target` field on `EvaluationLog` is not populated by complyctl today (zero-value)
+- complyctl merges multiple targets into a single `EvaluationLog`, making the hierarchy unreliable for per-target attribution
+
+`GemaraEvidence` already carries every field needed for a complete OTel log record. The gap is only `compliance.status`, which is a pure function of `Result`.
 
 ## What Changes
 
@@ -24,30 +26,41 @@ Proofwatch should accept an `EvaluationLog`, fan out to one OTel log record per 
 - `proofwatch/ocsf.go`, `proofwatch/ocsf_test.go`, `go-ocsf` dependency
 - `transform/ocsf` processor from all collector configs
 - `compass` service from `compose.yaml`
-- Compass cert generation from `Makefile` and `hack/self-signed-cert/`
-- truthbeam from `beacon-distro/manifest.yaml` (OCB manifest)
-- All truthbeam config from collector configs
+- Cert generation from `Makefile` and `hack/self-signed-cert/`
+- truthbeam from collector distro manifest
+- All truthbeam/OCSF config from collector configs
+- `oapi-codegen` from CI verify-codegen job (only needed for truthbeam's generated client)
+- `simulateTruthBeamEnrichment` from `validate-logs` CLI
 
 **Add:**
-- `EvaluationLog` fan-out in proofwatch: accept `gemara.EvaluationLog`, walk `Evaluations[] → AssessmentLogs[]`, emit one OTel log record per assessment with inherited `Target` and `Control` context
-- `compliance.status` local derivation in proofwatch (port `mapResult()` from truthbeam `internal/applier/status.go`)
-- Full Gemara-to-OTel semantic convention attribute mapping in proofwatch
+- `compliance.status` derivation in `GemaraEvidence.Attributes()` via ported `MapResult()` function
+- `proofwatch/status.go`: `ComplianceStatus` type and `MapResult()` from truthbeam `internal/applier/status.go`
+- ClickHouse exporter to collector distro manifest
+
+**Rename (repo alignment):**
+- Go module: `complybeacon` → `complytime-collector-components`
+- Directory: `beacon-distro/` → `collector-distro/`
+- Distro binary: `otelcol-beacon` → `otelcol-complytime`
+- Container image: `complybeacon-beacon-distro` → `complytime-collector-distro`
+- Semantic convention entity: `beacon.evidence` → `complytime.evidence`
+- Registry manifest name: `beacon` → `complytime`
+- All CI workflow job names, image references, and docs updated accordingly
 
 **Update:**
-- `beacon-distro/manifest.yaml`: remove truthbeam module
-- `beacon-distro/config.yaml`: remove truthbeam and transform/ocsf processors; logs pipeline = `batch` only
-- `hack/demo/demo-config.yaml`: same pipeline simplification
-- `compose.yaml`: remove compass service, compass cert mounts, `depends_on`
-- `Makefile`: remove cert generation, update semantic check targets
-- `model/attributes.yaml`: remove `compliance.enrichment.status`; downgrade catalog-only attributes
-- Docs: `DESIGN.md`, `DEVELOPMENT.md`, `README.md`
+- `collector-distro/manifest.yaml`: remove truthbeam module, add clickhouseexporter
+- `collector-distro/config.yaml`: logs pipeline = `batch` only
+- `hack/demo/demo-config.yaml`: remove truthbeam and transform/ocsf from pipeline
+- `compose.yaml`: remove compass service, cert mounts, `depends_on`; update distro context path
+- `Makefile`: remove cert generation, truthbeam from MODULES, update semantic check targets, remove truthbeam codegen
+- CI: update workflows, dependabot, sonar config
+- Docs: `DESIGN.md`, `DEVELOPMENT.md`, `README.md`, `proofwatch/README.md`, publish_image docs, Hyperproof integration docs
 
 ## Capabilities
 
 ### New Capabilities
 
-- **EvaluationLog fan-out**: Proofwatch accepts a Gemara `EvaluationLog` and produces one OTel log record per `AssessmentLog`, with `Target` and `Control` context propagated from parent objects
-- **Self-contained attribute mapping**: Proofwatch maps all Gemara fields to OTel semantic conventions at the source, including local `compliance.status` derivation
+- **Self-contained attribute mapping**: Proofwatch derives `compliance.status` locally from `gemara.Result` via `MapResult()`, eliminating the need for in-pipeline enrichment
+- **ClickHouse export**: Collector distro includes ClickHouse exporter for analytics and long-term storage
 
 ### Removed Capabilities
 
@@ -56,12 +69,17 @@ Proofwatch should accept an `EvaluationLog`, fan out to one OTel log record per 
 - **`compliance.enrichment.status`**: Removed -- no enrichment, no enrichment status
 - **OCSF evidence format**: Removed -- no consumers
 
+### Changed Capabilities
+
+- **`GemaraEvidence.Attributes()`**: Now includes `compliance.status` in every emitted attribute set
+- **`validate-logs` CLI**: Gemara-only, no format argument, no simulated enrichment
+
 ## Impact
 
-- **proofwatch module**: New `EvaluationLog` fan-out capability; `ocsf.go` deleted; `go-ocsf` dropped; `mapResult()` ported from truthbeam
-- **truthbeam module**: Deleted entirely
-- **beacon-distro**: `manifest.yaml` removes truthbeam module; custom distro retained for non-standard receivers/exporters/extensions but carries no custom processor code
+- **proofwatch module**: `ocsf.go` deleted; `go-ocsf` dropped; `MapResult()` added in `status.go`; `GemaraEvidence.Attributes()` gains `compliance.status`; tests updated
+- **truthbeam module**: Deleted entirely (~5,000 lines removed)
+- **collector-distro**: Renamed from `beacon-distro`; manifest removes truthbeam, adds clickhouseexporter; custom distro retained for non-standard components but carries no custom processor code
 - **Deployment**: Single collector container, no sidecar. No mTLS. `docker compose up` starts loki + grafana + collector only.
 - **Attribute model**: `compliance.enrichment.status` removed; four catalog-derived attributes downgraded
-- **Upstream dependency**: complyctl must populate `EvaluationLog.Target` (currently zero-valued in `evaluator.go` `GemaraLog()`)
+- **Entity model**: `beacon.evidence` → `complytime.evidence`
 - **No downstream impact**: No external OCSF consumers; no known consumers of catalog-derived attributes

--- a/openspec/changes/simplify-oci-enrichment/specs/gemara-otel-mapping/spec.md
+++ b/openspec/changes/simplify-oci-enrichment/specs/gemara-otel-mapping/spec.md
@@ -9,12 +9,16 @@ The `OCSFEvidence` type, `go-ocsf` dependency, and `transform/ocsf` collector pr
 - **THEN** no source file SHALL import `github.com/Santiago-Labs/go-ocsf`
 - **AND** no collector config SHALL reference a `transform/ocsf` processor
 
+#### Scenario: OCSF test helpers removed
+- **WHEN** `ocsf_test.go` is deleted
+- **THEN** `proofwatch_test.go` SHALL use `createTestGemaraEvidence()` (from `gemara_test.go`) instead of `createTestEvidence()`
+
 ### Requirement: truthbeam processor
 
 The `truthbeam/` module SHALL be deleted entirely. The collector SHALL NOT include a custom truthbeam processor.
 
 #### Scenario: No custom processor in distro
-- **WHEN** the collector distro is built from `beacon-distro/manifest.yaml`
+- **WHEN** the collector distro is built from `collector-distro/manifest.yaml`
 - **THEN** the manifest SHALL NOT reference the truthbeam module
 - **AND** no collector config SHALL reference a `truthbeam` processor
 
@@ -27,6 +31,12 @@ The `compass` container, mTLS cert generation, generated OpenAPI client, and all
 - **THEN** it SHALL NOT require a `compass` or `gemara-content-service` sidecar
 - **AND** `compose.yaml` SHALL NOT define a `compass` service
 
+#### Scenario: Cert infrastructure removed
+- **WHEN** the change is complete
+- **THEN** `hack/self-signed-cert/openssl.cnf` SHALL be deleted
+- **AND** the `generate-self-signed-cert` Makefile target SHALL be removed
+- **AND** no cert volume mounts SHALL exist in `compose.yaml`
+
 ### Requirement: Catalog-derived enrichment attributes
 
 The following attributes SHALL NOT be populated by any pipeline component in the default configuration: `compliance.control.category`, `compliance.frameworks`, `compliance.requirements`, `compliance.risk.level`, `compliance.enrichment.status`.
@@ -35,51 +45,54 @@ The following attributes SHALL NOT be populated by any pipeline component in the
 - **WHEN** a Gemara evidence log record is exported by the collector
 - **THEN** it SHALL NOT contain `compliance.enrichment.status`
 
+### Requirement: EvaluationLog fan-out
+
+The `EvaluationLog` fan-out described in the initial draft is REMOVED from scope. complyctl plugins operate at the `AssessmentLog` + `Metadata` level and do not have access to the full `EvaluationLog` hierarchy. The existing `GemaraEvidence` type is the correct abstraction.
+
+#### Rationale
+- Plugins produce individual assessment records, not full evaluation hierarchies
+- `EvaluationLog.Target` is not populated by complyctl (zero-value)
+- complyctl merges multiple targets into a single `EvaluationLog`
+
 ---
 
 ## ADDED Requirements
 
-### Requirement: EvaluationLog fan-out
+### Requirement: Local compliance.status derivation on GemaraEvidence
 
-Proofwatch SHALL accept a `gemara.EvaluationLog` and produce one OTel log record per `AssessmentLog` entry. Each record SHALL carry context propagated from the parent `EvaluationLog` and `ControlEvaluation` objects.
+Proofwatch SHALL derive `compliance.status` from the Gemara `Result` field and include it in `GemaraEvidence.Attributes()`.
 
-#### Scenario: Fan-out produces correct record count
-- **WHEN** an `EvaluationLog` contains 2 `ControlEvaluation` entries, each with 3 `AssessmentLog` entries
-- **THEN** proofwatch SHALL emit exactly 6 OTel log records
+#### Implementation
+A `ComplianceStatus` type and `MapResult()` function SHALL be added in `proofwatch/status.go`, ported from `truthbeam/internal/applier/status.go`.
 
-#### Scenario: Target context propagation
-- **WHEN** an `EvaluationLog` has `Target.Name` = `"org-infra"` and `Target.Id` = `"complytime/org-infra"`
-- **THEN** every emitted log record SHALL contain `policy.target.name` = `"org-infra"` and `policy.target.id` = `"complytime/org-infra"`
+#### Scenario: Result-to-status mapping
+- **WHEN** `Result` = `Passed` **THEN** `compliance.status` = `"Compliant"`
+- **WHEN** `Result` = `Failed` **THEN** `compliance.status` = `"Non-Compliant"`
+- **WHEN** `Result` = `NotApplicable` or `NotRun` **THEN** `compliance.status` = `"Not Applicable"`
+- **WHEN** `Result` is any other value **THEN** `compliance.status` = `"Unknown"`
 
-#### Scenario: Control context propagation
-- **WHEN** a `ControlEvaluation` has `Control.EntryId` = `"OSPS-QA-07"` and `Control.ReferenceId` = `"OSPS-B"`
-- **THEN** every log record emitted from that evaluation's `AssessmentLogs` SHALL contain `compliance.control.id` = `"OSPS-QA-07"` and `compliance.control.catalog.id` = `"OSPS-B"`
-
-#### Scenario: Zero-value Target handled gracefully
-- **WHEN** an `EvaluationLog` has a zero-value `Target` (empty `Name`, `Id`, etc.)
-- **THEN** the emitted log records SHALL omit `policy.target.*` attributes rather than emitting empty strings
+#### Scenario: compliance.status present in GemaraEvidence attributes
+- **WHEN** a caller constructs a `GemaraEvidence` with `Result` = `Passed` and calls `Attributes()`
+- **THEN** the returned attributes SHALL include `compliance.status` = `"Compliant"` alongside `policy.evaluation.result` = `"Passed"`
 
 ### Requirement: Complete Gemara-to-OTel semantic convention mapping
 
-Each emitted log record SHALL contain the following OTel attributes mapped from the Gemara hierarchy:
+Each `GemaraEvidence` log record SHALL contain the following OTel attributes:
 
 | Source | Gemara Field | OTel Attribute |
 |:--|:--|:--|
-| EvaluationLog | `Target.Name` | `policy.target.name` |
-| EvaluationLog | `Target.Id` | `policy.target.id` |
-| EvaluationLog | `Target.Type` | `policy.target.type` |
-| EvaluationLog | `Target.Environment` | `policy.target.environment` |
-| EvaluationLog | `Metadata.Author.Name` | `policy.engine.name` |
-| EvaluationLog | `Metadata.Author.Version` | `policy.engine.version` |
-| EvaluationLog | `Metadata.Id` | `compliance.assessment.id` |
-| ControlEvaluation | `Control.EntryId` | `compliance.control.id` |
-| ControlEvaluation | `Control.ReferenceId` | `compliance.control.catalog.id` |
+| Metadata | `Author.Name` | `policy.engine.name` |
+| Metadata | `Author.Version` | `policy.engine.version` |
+| Metadata | `Author.Uri` | `policy.rule.uri` |
+| Metadata | `Id` | `compliance.assessment.id` |
+| AssessmentLog | `Requirement.EntryId` | `compliance.control.id` |
+| AssessmentLog | `Requirement.ReferenceId` | `compliance.control.catalog.id` |
 | AssessmentLog | `Result` | `policy.evaluation.result` |
 | AssessmentLog | `Plan.EntryId` | `policy.rule.id` |
 | AssessmentLog | `Message` | `policy.evaluation.message` |
 | AssessmentLog | `Recommendation` | `compliance.remediation.description` |
 | AssessmentLog | `Applicability` | `compliance.control.applicability` |
-| *(derived)* | `mapResult(Result)` | `compliance.status` |
+| *(derived)* | `MapResult(Result)` | `compliance.status` |
 
 #### Scenario: Nil Plan omits policy.rule.id
 - **WHEN** an `AssessmentLog` has `Plan` = nil
@@ -89,31 +102,57 @@ Each emitted log record SHALL contain the following OTel attributes mapped from 
 - **WHEN** `AssessmentLog.Message` is empty
 - **THEN** `policy.evaluation.message` SHALL NOT be present on the log record
 
-### Requirement: Local compliance.status derivation
-
-Proofwatch SHALL derive `compliance.status` from the Gemara `Result` field using a local mapping function.
-
-#### Scenario: Result-to-status mapping
-- **WHEN** `Result` = `Passed` **THEN** `compliance.status` = `"Compliant"`
-- **WHEN** `Result` = `Failed` **THEN** `compliance.status` = `"Non-Compliant"`
-- **WHEN** `Result` = `NotApplicable` or `NotRun` **THEN** `compliance.status` = `"Not Applicable"`
-- **WHEN** `Result` = `Unknown` **THEN** `compliance.status` = `"Unknown"`
-
 ### Requirement: GemaraEvidence backward compatibility
 
-The existing `GemaraEvidence` type and its `Attributes()` method SHALL be retained for callers that produce individual assessment records. The `EvaluationLog` fan-out is an additional capability.
+The existing `GemaraEvidence` type and its `Attributes()` method SHALL be retained and enhanced with `compliance.status`. No new evidence types are introduced.
 
 #### Scenario: Existing GemaraEvidence still functional
 - **WHEN** a caller constructs a `GemaraEvidence` and calls `Attributes()`
-- **THEN** the returned attributes SHALL match the current behavior (per migrate-gemara-sdk spec)
+- **THEN** the returned attributes SHALL include all previously-emitted attributes plus `compliance.status`
 
 ### Requirement: No custom processor code in collector distro
 
-The collector distro SHALL NOT include custom processor code. The OCB manifest SHALL only reference community-maintained processors. Non-standard receivers, exporters, and extensions are retained.
+The collector distro SHALL NOT include custom processor code. The OCB manifest SHALL only reference community-maintained processors. Non-standard receivers, exporters, extensions, and connectors are retained.
 
 #### Scenario: Minimal logs pipeline
 - **WHEN** the collector config defines a logs pipeline
 - **THEN** the processors list SHALL NOT include `truthbeam` or `transform/ocsf`
+
+### Requirement: Rename from complybeacon to complytime-collector-components
+
+All internal references SHALL be updated to match the renamed GitHub repository.
+
+#### Scenario: Go module path
+- **WHEN** proofwatch is imported
+- **THEN** the module path SHALL be `github.com/complytime/complytime-collector-components/proofwatch`
+
+#### Scenario: Collector distro
+- **WHEN** the collector distro is built
+- **THEN** the directory SHALL be `collector-distro/`
+- **AND** the binary SHALL be named `otelcol-complytime`
+- **AND** the container image SHALL be `complytime-collector-distro`
+
+#### Scenario: Entity name
+- **WHEN** the semantic convention entity is referenced
+- **THEN** the entity id SHALL be `entity.complytime.evidence` with name `complytime.evidence`
+
+### Requirement: ClickHouse exporter
+
+The collector distro manifest SHALL include the ClickHouse exporter component.
+
+#### Scenario: ClickHouse in manifest
+- **WHEN** the collector distro is built from `collector-distro/manifest.yaml`
+- **THEN** the exporters list SHALL include `clickhouseexporter` at the same version as other contrib components
+
+### Requirement: validate-logs CLI simplification
+
+The `validate-logs` CLI SHALL be simplified to Gemara-only mode.
+
+#### Scenario: No format argument
+- **WHEN** `validate-logs` is invoked
+- **THEN** it SHALL accept an optional output file path as its only argument
+- **AND** it SHALL generate Gemara evidence logs only (no OCSF, no format flag)
+- **AND** it SHALL NOT simulate truthbeam enrichment
 
 ---
 
@@ -126,3 +165,7 @@ If consumers require `compliance.control.category`, `compliance.frameworks`, `co
 ### Requirement: complyctl Target population
 
 complyctl SHALL populate `EvaluationLog.Target` with the scanned repository's `Resource` data (`Name`, `Id`, `Type`). This is an upstream dependency tracked in the complyctl repository.
+
+### Requirement: EvaluationLog fan-out (future)
+
+If complyctl evolves to produce per-target `EvaluationLog` objects with populated `Target` fields, proofwatch MAY add a `LogEvaluationLog()` method as an additional capability. This would walk `Evaluations[] → AssessmentLogs[]` and emit one OTel log record per assessment with inherited `Target` and `Control` context. This is deferred until the upstream data model supports it.

--- a/openspec/changes/simplify-oci-enrichment/specs/gemara-otel-mapping/spec.md
+++ b/openspec/changes/simplify-oci-enrichment/specs/gemara-otel-mapping/spec.md
@@ -1,0 +1,128 @@
+## REMOVED Requirements
+
+### Requirement: OCSF evidence support
+
+The `OCSFEvidence` type, `go-ocsf` dependency, and `transform/ocsf` collector processor SHALL be removed. Proofwatch SHALL only support Gemara-format evidence.
+
+#### Scenario: OCSF code removed
+- **WHEN** the proofwatch module is built
+- **THEN** no source file SHALL import `github.com/Santiago-Labs/go-ocsf`
+- **AND** no collector config SHALL reference a `transform/ocsf` processor
+
+### Requirement: truthbeam processor
+
+The `truthbeam/` module SHALL be deleted entirely. The collector SHALL NOT include a custom truthbeam processor.
+
+#### Scenario: No custom processor in distro
+- **WHEN** the collector distro is built from `beacon-distro/manifest.yaml`
+- **THEN** the manifest SHALL NOT reference the truthbeam module
+- **AND** no collector config SHALL reference a `truthbeam` processor
+
+### Requirement: Compass / HTTP enrichment service
+
+The `compass` container, mTLS cert generation, generated OpenAPI client, and all Compass-related deployment infrastructure SHALL be removed.
+
+#### Scenario: Self-contained collector
+- **WHEN** the collector is deployed
+- **THEN** it SHALL NOT require a `compass` or `gemara-content-service` sidecar
+- **AND** `compose.yaml` SHALL NOT define a `compass` service
+
+### Requirement: Catalog-derived enrichment attributes
+
+The following attributes SHALL NOT be populated by any pipeline component in the default configuration: `compliance.control.category`, `compliance.frameworks`, `compliance.requirements`, `compliance.risk.level`, `compliance.enrichment.status`.
+
+#### Scenario: No catalog-only attributes in output
+- **WHEN** a Gemara evidence log record is exported by the collector
+- **THEN** it SHALL NOT contain `compliance.enrichment.status`
+
+---
+
+## ADDED Requirements
+
+### Requirement: EvaluationLog fan-out
+
+Proofwatch SHALL accept a `gemara.EvaluationLog` and produce one OTel log record per `AssessmentLog` entry. Each record SHALL carry context propagated from the parent `EvaluationLog` and `ControlEvaluation` objects.
+
+#### Scenario: Fan-out produces correct record count
+- **WHEN** an `EvaluationLog` contains 2 `ControlEvaluation` entries, each with 3 `AssessmentLog` entries
+- **THEN** proofwatch SHALL emit exactly 6 OTel log records
+
+#### Scenario: Target context propagation
+- **WHEN** an `EvaluationLog` has `Target.Name` = `"org-infra"` and `Target.Id` = `"complytime/org-infra"`
+- **THEN** every emitted log record SHALL contain `policy.target.name` = `"org-infra"` and `policy.target.id` = `"complytime/org-infra"`
+
+#### Scenario: Control context propagation
+- **WHEN** a `ControlEvaluation` has `Control.EntryId` = `"OSPS-QA-07"` and `Control.ReferenceId` = `"OSPS-B"`
+- **THEN** every log record emitted from that evaluation's `AssessmentLogs` SHALL contain `compliance.control.id` = `"OSPS-QA-07"` and `compliance.control.catalog.id` = `"OSPS-B"`
+
+#### Scenario: Zero-value Target handled gracefully
+- **WHEN** an `EvaluationLog` has a zero-value `Target` (empty `Name`, `Id`, etc.)
+- **THEN** the emitted log records SHALL omit `policy.target.*` attributes rather than emitting empty strings
+
+### Requirement: Complete Gemara-to-OTel semantic convention mapping
+
+Each emitted log record SHALL contain the following OTel attributes mapped from the Gemara hierarchy:
+
+| Source | Gemara Field | OTel Attribute |
+|:--|:--|:--|
+| EvaluationLog | `Target.Name` | `policy.target.name` |
+| EvaluationLog | `Target.Id` | `policy.target.id` |
+| EvaluationLog | `Target.Type` | `policy.target.type` |
+| EvaluationLog | `Target.Environment` | `policy.target.environment` |
+| EvaluationLog | `Metadata.Author.Name` | `policy.engine.name` |
+| EvaluationLog | `Metadata.Author.Version` | `policy.engine.version` |
+| EvaluationLog | `Metadata.Id` | `compliance.assessment.id` |
+| ControlEvaluation | `Control.EntryId` | `compliance.control.id` |
+| ControlEvaluation | `Control.ReferenceId` | `compliance.control.catalog.id` |
+| AssessmentLog | `Result` | `policy.evaluation.result` |
+| AssessmentLog | `Plan.EntryId` | `policy.rule.id` |
+| AssessmentLog | `Message` | `policy.evaluation.message` |
+| AssessmentLog | `Recommendation` | `compliance.remediation.description` |
+| AssessmentLog | `Applicability` | `compliance.control.applicability` |
+| *(derived)* | `mapResult(Result)` | `compliance.status` |
+
+#### Scenario: Nil Plan omits policy.rule.id
+- **WHEN** an `AssessmentLog` has `Plan` = nil
+- **THEN** the emitted log record SHALL NOT contain `policy.rule.id`
+
+#### Scenario: Empty optional fields omitted
+- **WHEN** `AssessmentLog.Message` is empty
+- **THEN** `policy.evaluation.message` SHALL NOT be present on the log record
+
+### Requirement: Local compliance.status derivation
+
+Proofwatch SHALL derive `compliance.status` from the Gemara `Result` field using a local mapping function.
+
+#### Scenario: Result-to-status mapping
+- **WHEN** `Result` = `Passed` **THEN** `compliance.status` = `"Compliant"`
+- **WHEN** `Result` = `Failed` **THEN** `compliance.status` = `"Non-Compliant"`
+- **WHEN** `Result` = `NotApplicable` or `NotRun` **THEN** `compliance.status` = `"Not Applicable"`
+- **WHEN** `Result` = `Unknown` **THEN** `compliance.status` = `"Unknown"`
+
+### Requirement: GemaraEvidence backward compatibility
+
+The existing `GemaraEvidence` type and its `Attributes()` method SHALL be retained for callers that produce individual assessment records. The `EvaluationLog` fan-out is an additional capability.
+
+#### Scenario: Existing GemaraEvidence still functional
+- **WHEN** a caller constructs a `GemaraEvidence` and calls `Attributes()`
+- **THEN** the returned attributes SHALL match the current behavior (per migrate-gemara-sdk spec)
+
+### Requirement: No custom processor code in collector distro
+
+The collector distro SHALL NOT include custom processor code. The OCB manifest SHALL only reference community-maintained processors. Non-standard receivers, exporters, and extensions are retained.
+
+#### Scenario: Minimal logs pipeline
+- **WHEN** the collector config defines a logs pipeline
+- **THEN** the processors list SHALL NOT include `truthbeam` or `transform/ocsf`
+
+---
+
+## DEFERRED Requirements
+
+### Requirement: Query-time catalog enrichment
+
+If consumers require `compliance.control.category`, `compliance.frameworks`, `compliance.requirements`, or `compliance.risk.level`, these SHALL be resolved at query time (e.g., Grafana variable, Loki structured metadata join) rather than at pipeline time. Implementation is out of scope for this change.
+
+### Requirement: complyctl Target population
+
+complyctl SHALL populate `EvaluationLog.Target` with the scanned repository's `Resource` data (`Name`, `Id`, `Type`). This is an upstream dependency tracked in the complyctl repository.

--- a/openspec/changes/simplify-oci-enrichment/specs/gemara-otel-mapping/spec.md
+++ b/openspec/changes/simplify-oci-enrichment/specs/gemara-otel-mapping/spec.md
@@ -47,7 +47,7 @@ The following attributes SHALL NOT be populated by any pipeline component in the
 
 ### Requirement: EvaluationLog fan-out
 
-The `EvaluationLog` fan-out described in the initial draft is REMOVED from scope. complyctl plugins operate at the `AssessmentLog` + `Metadata` level and do not have access to the full `EvaluationLog` hierarchy. The existing `GemaraEvidence` type is the correct abstraction.
+The `EvaluationLog` fan-out described in the initial draft is REMOVED from scope. complyctl providers operate at the `AssessmentLog` + `Metadata` level and do not have access to the full `EvaluationLog` hierarchy. The existing `GemaraEvidence` type is the correct abstraction.
 
 #### Rationale
 - Plugins produce individual assessment records, not full evaluation hierarchies

--- a/openspec/changes/simplify-oci-enrichment/tasks.md
+++ b/openspec/changes/simplify-oci-enrichment/tasks.md
@@ -1,88 +1,97 @@
-## 1. Proofwatch: EvaluationLog Fan-out
+## 1. Proofwatch: Add compliance.status to GemaraEvidence
 
-- [ ] 1.1 Add `EvaluationLogEmitter` (or similar) that accepts `gemara.EvaluationLog` and produces `[]plog.LogRecord` (or equivalent OTel log output)
-- [ ] 1.2 Implement fan-out: walk `Evaluations[] → AssessmentLogs[]`, emit one record per assessment
-- [ ] 1.3 Propagate `EvaluationLog.Target` fields to `policy.target.*` attributes on each record; omit when zero-value
-- [ ] 1.4 Propagate `ControlEvaluation.Control` fields to `compliance.control.id` and `compliance.control.catalog.id` on each record
-- [ ] 1.5 Map `EvaluationLog.Metadata.Author` to `policy.engine.name`, `policy.engine.version`
-- [ ] 1.6 Map `EvaluationLog.Metadata.Id` to `compliance.assessment.id`
-- [ ] 1.7 Map assessment-level fields: `Result`, `Plan`, `Message`, `Recommendation`, `Applicability`
-- [ ] 1.8 Port `mapResult()` from `truthbeam/internal/applier/status.go` to proofwatch; derive `compliance.status` locally
-- [ ] 1.9 Nil-guard `Plan` -- omit `policy.rule.id` when nil (per migrate-gemara-sdk spec)
-- [ ] 1.10 Omit attributes for empty optional fields (`Message`, `Recommendation`, `Target.*`)
-- [ ] 1.11 Write tests: fan-out record count, target propagation, control propagation, nil Plan, zero-value Target, status derivation
-- [ ] 1.12 Retain existing `GemaraEvidence` type and `Attributes()` for backward compatibility
+- [ ] 1.1 Create `proofwatch/status.go`: port `ComplianceStatus` type and `MapResult()` from `truthbeam/internal/applier/status.go`
+- [ ] 1.2 Add `compliance.status` attribute to `GemaraEvidence.Attributes()` via `MapResult(g.Result).String()`
+- [ ] 1.3 Add `compliance.status` assertion to `TestGemaraEvidenceAttributes` in `gemara_test.go`
+- [ ] 1.4 Update `TestGemaraEvidenceAttributesDifferentResults` to verify both `policy.evaluation.result` and `compliance.status` for each result type
 
 ## 2. Remove OCSF Support
 
 - [ ] 2.1 Delete `proofwatch/ocsf.go` and `proofwatch/ocsf_test.go`
-- [ ] 2.2 Remove `ocsf` and `both` modes from `proofwatch/cmd/validate-logs/main.go`; keep `gemara` only
-- [ ] 2.3 Remove `go-ocsf` dependency from `proofwatch/go.mod`; run `go mod tidy`
-- [ ] 2.4 Remove OCSF test helpers from `proofwatch/proofwatch_test.go` if any remain
-- [ ] 2.5 Remove `transform/ocsf` processor from `beacon-distro/config.yaml`
-- [ ] 2.6 Remove `transform/ocsf` processor from `hack/demo/demo-config.yaml`
-- [ ] 2.7 Remove `transform/ocsf` from logs pipeline in `beacon-distro/config.yaml` service section
+- [ ] 2.2 Replace `createTestEvidence()` calls in `proofwatch/proofwatch_test.go` with `createTestGemaraEvidence()`
+- [ ] 2.3 Remove stale comment referencing `createTestEvidence` / `ocsf_test.go` from `proofwatch_test.go`
+- [ ] 2.4 Simplify `proofwatch/cmd/validate-logs/main.go`: remove OCSF imports, `generateOCSFLog()`, `simulateTruthBeamEnrichment()`, `stringPtr()`, format argument; CLI takes optional output file path only
+- [ ] 2.5 Remove `go-ocsf` dependency: `go mod tidy` (removes `github.com/Santiago-Labs/go-ocsf` and transitive deps like `arrow-go`, `flatbuffers`, etc.)
+- [ ] 2.6 Remove `transform/ocsf` processor from `beacon-distro/config.yaml` (both definition and pipeline reference)
+- [ ] 2.7 Remove `transform/ocsf` processor from `hack/demo/demo-config.yaml` (extensive -- includes OCSF field extraction, severity mapping, S3 partitioning)
 
 ## 3. Delete truthbeam Module
 
-- [ ] 3.1 Delete `truthbeam/` directory entirely (config, processor, factory, applier, client, metadata, tests, go.mod, go.sum)
+- [ ] 3.1 Delete `truthbeam/` directory entirely (config, processor, factory, applier, client, metadata, tests, go.mod, go.sum, `.gaze/baseline.json`, README)
 - [ ] 3.2 Remove truthbeam module from `beacon-distro/manifest.yaml`
-- [ ] 3.3 Remove `truthbeam` processor from `beacon-distro/config.yaml` (both processor definition and pipeline reference)
-- [ ] 3.4 Remove `truthbeam` processor from `hack/demo/demo-config.yaml`
-- [ ] 3.5 Remove truthbeam references from `sonar-project.properties`
-- [ ] 3.6 Remove truthbeam references from `.github/workflows/ci_local.yml`
-- [ ] 3.7 Remove truthbeam references from `.github/workflows/ci_crapload.yml` if present
-- [ ] 3.8 Remove truthbeam test/build targets from `Makefile`
-- [ ] 3.9 Remove truthbeam references from `.mega-linter.yml` if present
+- [ ] 3.3 Remove `truthbeam` processor config and pipeline reference from `beacon-distro/config.yaml`
+- [ ] 3.4 Remove `truthbeam` processor config (endpoint, compression, TLS) and pipeline reference from `hack/demo/demo-config.yaml`
+- [ ] 3.5 Remove truthbeam from `sonar-project.properties` (`sonar.modules`, `truthbeam.sonar.*` properties)
+- [ ] 3.6 Update `.github/workflows/ci_sonarcloud.yml`: replace coverage merge (`cat + tail`) with single file copy
+- [ ] 3.7 Update `.github/workflows/ci_local.yml`: remove truthbeam from `verify-codegen` deps loop; remove `oapi-codegen` install step (only needed for truthbeam generated client)
+- [ ] 3.8 Update `.github/workflows/ci_local.yml`: update weaver-semantic-check step description (remove "OCSF")
+- [ ] 3.9 Remove truthbeam from `.github/dependabot.yml` gomod directories
+- [ ] 3.10 Update `Makefile` MODULES: `./proofwatch ./truthbeam` → `./proofwatch`
+- [ ] 3.11 Remove `weaver-codegen` truthbeam target (`weaver registry generate ... truthbeam/internal/applier`)
 
 ## 4. Remove Compass Service and Cert Infrastructure
 
 - [ ] 4.1 Remove `compass` service from `compose.yaml`
 - [ ] 4.2 Remove `depends_on: compass` from `collector` service in `compose.yaml`
-- [ ] 4.3 Remove compass cert volume mounts from `collector` service in `compose.yaml`
-- [ ] 4.4 Remove compass cert generation from `Makefile` (`generate-self-signed-cert` target: compass key, CSR, cert steps)
-- [ ] 4.5 Clean `hack/self-signed-cert/openssl.cnf` of compass-specific entries
-- [ ] 4.6 Remove `hack/demo/config.yaml` if it was compass-specific
-- [ ] 4.7 Remove compass-related sample data (`hack/sampledata/osps.yaml` if still present)
+- [ ] 4.3 Remove truthbeam cert volume mount from `collector` service in `compose.yaml`
+- [ ] 4.4 Delete `hack/self-signed-cert/` directory (only `openssl.cnf` is tracked; certs are gitignored)
+- [ ] 4.5 Remove `generate-self-signed-cert` Makefile target and `CERT_DIR`/`OPENSSL_CNF` variables
 
-## 5. Update Collector Configs
+## 5. Rename: complybeacon → complytime-collector-components
 
-- [ ] 5.1 Simplify `beacon-distro/config.yaml` logs pipeline to `receivers: [otlp] → processors: [batch] → exporters: [debug]`
-- [ ] 5.2 Simplify `hack/demo/demo-config.yaml` logs pipeline (remove truthbeam and transform/ocsf)
-- [ ] 5.3 Remove truthbeam endpoint/TLS/cache config from all collector configs
-- [ ] 5.4 Update `beacon-distro/Containerfile.collector` if it references compass certs or truthbeam config
+### 5.1 Go module and imports
+- [ ] 5.1.1 Update `proofwatch/go.mod` module path
+- [ ] 5.1.2 Update `proofwatch/proofwatch.go` import of `internal/metrics` and `ScopeName` constant
+- [ ] 5.1.3 Update `proofwatch/cmd/validate-logs/main.go` import and scope name string
 
-## 6. Update Makefile
+### 5.2 Collector distro
+- [ ] 5.2.1 `git mv beacon-distro collector-distro`
+- [ ] 5.2.2 Update `collector-distro/manifest.yaml`: dist name `otelcol-complytime`, module path, description, output_path `./collector`
+- [ ] 5.2.3 Update `collector-distro/Containerfile.collector`: labels, binary paths (`/otelcol-complytime`, `/etc/otelcol-complytime/config.yaml`), image source URL
+- [ ] 5.2.4 Update `compose.yaml` build context: `./collector-distro`
 
-- [ ] 6.1 Remove or simplify `generate-self-signed-cert` target (may still need truthbeam CA cert for other TLS uses, or remove entirely)
-- [ ] 6.2 Update `weaver-semantic-check` target: change `both` to `gemara`, update echo messages
-- [ ] 6.3 Update `weaver-semantic-check-verbose` target: same changes
-- [ ] 6.4 Remove any truthbeam-specific build/test/lint targets
+### 5.3 Semantic convention model
+- [ ] 5.3.1 Update `model/entities.yaml`: `entity.beacon.evidence` → `entity.complytime.evidence`, `beacon.evidence` → `complytime.evidence`
+- [ ] 5.3.2 Update `model/registry_manifest.yaml`: name `beacon` → `complytime`, description, schema_base_url
 
-## 7. Update Attribute Model
+### 5.4 CI workflows
+- [ ] 5.4.1 Update `.github/workflows/ci_publish_ghcr.yml`: all job names (`build-beacon-distro` → `build-collector-distro`, etc.), image name, component_name, paths, needs references, summary table
+- [ ] 5.4.2 Update `.github/workflows/ci_publish_quay.yml`: job names, image names (GHCR + Quay), crane tag command
+- [ ] 5.4.3 Update `.github/dependabot.yml`: remove stale "used in complybeacon" comment
 
-- [ ] 7.1 Remove `compliance.enrichment.status` from `model/attributes.yaml`
-- [ ] 7.2 Downgrade or annotate `compliance.control.category`, `compliance.frameworks`, `compliance.requirements`, `compliance.risk.level` as not populated in default mode
-- [ ] 7.3 Regenerate attribute docs with `make weaver-docsgen`
+### 5.5 Documentation
+- [ ] 5.5.1 Rewrite `README.md`: update title, architecture overview (2 components, not 4), quick start
+- [ ] 5.5.2 Rewrite `docs/DESIGN.md`: remove truthbeam/compass sections, update architecture diagram, update code examples
+- [ ] 5.5.3 Rewrite `docs/DEVELOPMENT.md`: remove compass/truthbeam setup, update project structure, update clone URL, update Go workspace modules
+- [ ] 5.5.4 Update `proofwatch/README.md`: update import paths, remove truthbeam/compass note, update dev guide link
+- [ ] 5.5.5 Update `docs/publish_image/publish_image.md`: update cosign verify commands (image names), remove compass image note
+- [ ] 5.5.6 Update `docs/integration/Sync_Evidence2Hyperproof.md`: replace `Complybeacon` references with `ComplyTime Collector`
 
-## 8. Documentation
+## 6. Add ClickHouse Exporter
 
-- [ ] 8.1 Update `docs/DESIGN.md`: remove truthbeam/compass architecture, update pipeline diagram, update `GemaraEvidence` example
-- [ ] 8.2 Update `docs/DEVELOPMENT.md`: remove compass setup instructions, simplify collector startup
-- [ ] 8.3 Update `README.md`: update architecture overview, remove compass/truthbeam references
-- [ ] 8.4 Update `docs/publish_image/publish_image.md`: remove compass image references
-- [ ] 8.5 Update `truthbeam/README.md` → delete (module is gone)
-- [ ] 8.6 Update `proofwatch/README.md`: document EvaluationLog fan-out capability
-- [ ] 8.7 Update `docs/integration/Sync_Evidence2Hyperproof.md` if it references OCSF or compass
+- [ ] 6.1 Add `clickhouseexporter` to `collector-distro/manifest.yaml` at same version as other contrib components (v0.144.0)
+
+## 7. Update Makefile
+
+- [ ] 7.1 Update `weaver-semantic-check` target: remove format argument, update echo message
+- [ ] 7.2 Update `weaver-semantic-check-verbose` target: same changes
+
+## 8. Update Attribute Model
+
+- [ ] 8.1 Remove `compliance.enrichment.status` from `model/attributes.yaml`
+- [ ] 8.2 Downgrade or annotate `compliance.control.category`, `compliance.frameworks`, `compliance.requirements`, `compliance.risk.level` as not populated in default mode
+- [ ] 8.3 Regenerate attribute docs with `make weaver-docsgen`
+- [ ] 8.4 Regenerate Go code with `make weaver-codegen`
 
 ## 9. Verification
 
-- [ ] 9.1 `go build ./...` passes for proofwatch
-- [ ] 9.2 `go test ./...` passes for proofwatch
-- [ ] 9.3 `make weaver-semantic-check` passes with Gemara-only mode
-- [ ] 9.4 Collector distro builds successfully with `beacon-distro/Containerfile.collector`
-- [ ] 9.5 `docker compose up` starts without compass dependency
-- [ ] 9.6 No remaining references to `ocsf`, `compass`, or `truthbeam` in source files (grep verification)
+- [ ] 9.1 `go build -mod=readonly ./...` passes for proofwatch
+- [ ] 9.2 `go test -mod=readonly -count=1 ./...` passes for proofwatch (or sync vendor with `go mod vendor`)
+- [ ] 9.3 `go run -mod=readonly ./cmd/validate-logs` outputs correct attributes including `compliance.status`
+- [ ] 9.4 `make weaver-semantic-check` passes with Gemara-only mode
+- [ ] 9.5 Collector distro builds with `collector-distro/Containerfile.collector`
+- [ ] 9.6 `podman-compose up` starts without compass dependency
+- [ ] 9.7 No remaining references to `ocsf`, `compass`, `truthbeam`, `beacon`, or `complybeacon` in source files (excluding openspec/ and .git/)
 
 ## 10. Upstream (complyctl -- tracked separately)
 

--- a/openspec/changes/simplify-oci-enrichment/tasks.md
+++ b/openspec/changes/simplify-oci-enrichment/tasks.md
@@ -1,0 +1,90 @@
+## 1. Proofwatch: EvaluationLog Fan-out
+
+- [ ] 1.1 Add `EvaluationLogEmitter` (or similar) that accepts `gemara.EvaluationLog` and produces `[]plog.LogRecord` (or equivalent OTel log output)
+- [ ] 1.2 Implement fan-out: walk `Evaluations[] → AssessmentLogs[]`, emit one record per assessment
+- [ ] 1.3 Propagate `EvaluationLog.Target` fields to `policy.target.*` attributes on each record; omit when zero-value
+- [ ] 1.4 Propagate `ControlEvaluation.Control` fields to `compliance.control.id` and `compliance.control.catalog.id` on each record
+- [ ] 1.5 Map `EvaluationLog.Metadata.Author` to `policy.engine.name`, `policy.engine.version`
+- [ ] 1.6 Map `EvaluationLog.Metadata.Id` to `compliance.assessment.id`
+- [ ] 1.7 Map assessment-level fields: `Result`, `Plan`, `Message`, `Recommendation`, `Applicability`
+- [ ] 1.8 Port `mapResult()` from `truthbeam/internal/applier/status.go` to proofwatch; derive `compliance.status` locally
+- [ ] 1.9 Nil-guard `Plan` -- omit `policy.rule.id` when nil (per migrate-gemara-sdk spec)
+- [ ] 1.10 Omit attributes for empty optional fields (`Message`, `Recommendation`, `Target.*`)
+- [ ] 1.11 Write tests: fan-out record count, target propagation, control propagation, nil Plan, zero-value Target, status derivation
+- [ ] 1.12 Retain existing `GemaraEvidence` type and `Attributes()` for backward compatibility
+
+## 2. Remove OCSF Support
+
+- [ ] 2.1 Delete `proofwatch/ocsf.go` and `proofwatch/ocsf_test.go`
+- [ ] 2.2 Remove `ocsf` and `both` modes from `proofwatch/cmd/validate-logs/main.go`; keep `gemara` only
+- [ ] 2.3 Remove `go-ocsf` dependency from `proofwatch/go.mod`; run `go mod tidy`
+- [ ] 2.4 Remove OCSF test helpers from `proofwatch/proofwatch_test.go` if any remain
+- [ ] 2.5 Remove `transform/ocsf` processor from `beacon-distro/config.yaml`
+- [ ] 2.6 Remove `transform/ocsf` processor from `hack/demo/demo-config.yaml`
+- [ ] 2.7 Remove `transform/ocsf` from logs pipeline in `beacon-distro/config.yaml` service section
+
+## 3. Delete truthbeam Module
+
+- [ ] 3.1 Delete `truthbeam/` directory entirely (config, processor, factory, applier, client, metadata, tests, go.mod, go.sum)
+- [ ] 3.2 Remove truthbeam module from `beacon-distro/manifest.yaml`
+- [ ] 3.3 Remove `truthbeam` processor from `beacon-distro/config.yaml` (both processor definition and pipeline reference)
+- [ ] 3.4 Remove `truthbeam` processor from `hack/demo/demo-config.yaml`
+- [ ] 3.5 Remove truthbeam references from `sonar-project.properties`
+- [ ] 3.6 Remove truthbeam references from `.github/workflows/ci_local.yml`
+- [ ] 3.7 Remove truthbeam references from `.github/workflows/ci_crapload.yml` if present
+- [ ] 3.8 Remove truthbeam test/build targets from `Makefile`
+- [ ] 3.9 Remove truthbeam references from `.mega-linter.yml` if present
+
+## 4. Remove Compass Service and Cert Infrastructure
+
+- [ ] 4.1 Remove `compass` service from `compose.yaml`
+- [ ] 4.2 Remove `depends_on: compass` from `collector` service in `compose.yaml`
+- [ ] 4.3 Remove compass cert volume mounts from `collector` service in `compose.yaml`
+- [ ] 4.4 Remove compass cert generation from `Makefile` (`generate-self-signed-cert` target: compass key, CSR, cert steps)
+- [ ] 4.5 Clean `hack/self-signed-cert/openssl.cnf` of compass-specific entries
+- [ ] 4.6 Remove `hack/demo/config.yaml` if it was compass-specific
+- [ ] 4.7 Remove compass-related sample data (`hack/sampledata/osps.yaml` if still present)
+
+## 5. Update Collector Configs
+
+- [ ] 5.1 Simplify `beacon-distro/config.yaml` logs pipeline to `receivers: [otlp] → processors: [batch] → exporters: [debug]`
+- [ ] 5.2 Simplify `hack/demo/demo-config.yaml` logs pipeline (remove truthbeam and transform/ocsf)
+- [ ] 5.3 Remove truthbeam endpoint/TLS/cache config from all collector configs
+- [ ] 5.4 Update `beacon-distro/Containerfile.collector` if it references compass certs or truthbeam config
+
+## 6. Update Makefile
+
+- [ ] 6.1 Remove or simplify `generate-self-signed-cert` target (may still need truthbeam CA cert for other TLS uses, or remove entirely)
+- [ ] 6.2 Update `weaver-semantic-check` target: change `both` to `gemara`, update echo messages
+- [ ] 6.3 Update `weaver-semantic-check-verbose` target: same changes
+- [ ] 6.4 Remove any truthbeam-specific build/test/lint targets
+
+## 7. Update Attribute Model
+
+- [ ] 7.1 Remove `compliance.enrichment.status` from `model/attributes.yaml`
+- [ ] 7.2 Downgrade or annotate `compliance.control.category`, `compliance.frameworks`, `compliance.requirements`, `compliance.risk.level` as not populated in default mode
+- [ ] 7.3 Regenerate attribute docs with `make weaver-docsgen`
+
+## 8. Documentation
+
+- [ ] 8.1 Update `docs/DESIGN.md`: remove truthbeam/compass architecture, update pipeline diagram, update `GemaraEvidence` example
+- [ ] 8.2 Update `docs/DEVELOPMENT.md`: remove compass setup instructions, simplify collector startup
+- [ ] 8.3 Update `README.md`: update architecture overview, remove compass/truthbeam references
+- [ ] 8.4 Update `docs/publish_image/publish_image.md`: remove compass image references
+- [ ] 8.5 Update `truthbeam/README.md` → delete (module is gone)
+- [ ] 8.6 Update `proofwatch/README.md`: document EvaluationLog fan-out capability
+- [ ] 8.7 Update `docs/integration/Sync_Evidence2Hyperproof.md` if it references OCSF or compass
+
+## 9. Verification
+
+- [ ] 9.1 `go build ./...` passes for proofwatch
+- [ ] 9.2 `go test ./...` passes for proofwatch
+- [ ] 9.3 `make weaver-semantic-check` passes with Gemara-only mode
+- [ ] 9.4 Collector distro builds successfully with `beacon-distro/Containerfile.collector`
+- [ ] 9.5 `docker compose up` starts without compass dependency
+- [ ] 9.6 No remaining references to `ocsf`, `compass`, or `truthbeam` in source files (grep verification)
+
+## 10. Upstream (complyctl -- tracked separately)
+
+- [ ] 10.1 Update `complyctl/internal/output/evaluator.go` `GemaraLog()` to populate `EvaluationLog.Target` with scanned repository `Resource` data
+- [ ] 10.2 Consider per-target `EvaluationLog` generation (one log per target instead of merging)


### PR DESCRIPTION
## Summary

This PR adds a spec to support discussion of the following:

- Removal of OCSF support (not needed by consumers at this point)
- Removal of `truthbeam` and `compass` that support in-pipeline enrichment:
  - If we standardized on Gemara-based Evidence inputs being produced by `complyctl`, we have a pretty complete log
  - For static variables like framework mappings, adding and using a backend like ClickHouse makes query time enrichment more feasible.
- Renames `beacon` -> ComplyTime Distro

## Related Issues

- _Closes complytime/nunya#382  (makes obsolete) 

Contains diff from complytime/complytime-collector-components#192 

## Review Hints

N/A