### PR TITLE
chore: pins reusable workflows to v0.1.0

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   call_reusable_ci:
     name: Standardized CI
-    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
+    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
     permissions:
       contents: read
       issues: read

--- a/.github/workflows/ci_crapload.yml
+++ b/.github/workflows/ci_crapload.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   crapload:
     name: CRAP Load Analysis
-    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
     permissions:
       contents: read
 

--- a/.github/workflows/ci_dependencies.yml
+++ b/.github/workflows/ci_dependencies.yml
@@ -25,11 +25,11 @@ env:
 jobs:
   call_deps_reviewer:
     name: General
-    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
+    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
 
   call_dependabot_reviewer:
     name: Dependabot
-    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
+    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
 
   comment_on_dependabot_prs:
     name: Dependabot Comment

--- a/.github/workflows/ci_publish_ghcr.yml
+++ b/.github/workflows/ci_publish_ghcr.yml
@@ -56,7 +56,7 @@ jobs:
       security-events: write  # upload SARIF results
       id-token: write         # OIDC for registry auth
       actions: read           # access reusable workflow
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
     with:
       enable_osv: true
       enable_trivy_source: true
@@ -76,7 +76,7 @@ jobs:
       id-token: write      # OIDC for registry auth
       actions: read        # access reusable workflow
       attestations: write  # publish build provenance
-    uses: complytime/org-infra/.github/workflows/reusable_publish_ghcr.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_publish_ghcr.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
     with:
       component_name: beacon-distro
       containerfile_path: beacon-distro/Containerfile.collector
@@ -100,7 +100,7 @@ jobs:
       security-events: write  # upload SARIF results
       id-token: write         # OIDC for registry auth
       actions: read           # required by osv_scanner nested job
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
     with:
       enable_osv: false
       enable_trivy_source: false
@@ -119,7 +119,7 @@ jobs:
     permissions:
       packages: write  # attach signature to image
       id-token: write  # OIDC for keyless signing
-    uses: complytime/org-infra/.github/workflows/reusable_sign_and_verify.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_sign_and_verify.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
     with:
       image_name: ${{ needs.build-beacon-distro.outputs.image }}
       digest: ${{ needs.build-beacon-distro.outputs.digest }}

--- a/.github/workflows/ci_publish_quay.yml
+++ b/.github/workflows/ci_publish_quay.yml
@@ -80,7 +80,7 @@ jobs:
     needs: [setup, tag-ghcr]
     permissions:
       packages: read
-    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
     with:
       source_registry: ghcr.io
       source_image: complytime/complybeacon-beacon-distro

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -18,4 +18,4 @@ jobs:
       actions: read           # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
       security-events: write  # Require writing security events to upload SARIF file to security tab
       id-token: write         # Needed to access GitHub's OIDC token which verifies the authenticity of the result when publishing it.
-    uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
+    uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main

--- a/.github/workflows/ci_security.yml
+++ b/.github/workflows/ci_security.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write
       packages: write
       id-token: write
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
     with:
       # OSV focuses on known CVEs in dependencies; Trivy adds broader coverage
       enable_trivy_source: true
@@ -35,4 +35,4 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    uses: complytime/org-infra/.github/workflows/reusable_security.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
+    uses: complytime/org-infra/.github/workflows/reusable_security.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main

--- a/.github/workflows/ci_sonarcloud.yml
+++ b/.github/workflows/ci_sonarcloud.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
       pull-requests: read
     needs: generate-coverage
-    uses: complytime/org-infra/.github/workflows/reusable_sonarqube.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_sonarqube.yml@9205a3ac6b76b75dbe6e22b2f0f330bc8edbeb38 # main
     with:
       sonar_organization: ${{ vars.SONAR_ORGANIZATION }}
       sonar_project_key: ${{ vars.SONAR_PROJECT_KEY }}


### PR DESCRIPTION
## Summary

This PR pins the reusable workflows to the org-infra `v0.1.0` release SHA.

- `complytime/org-infra/.github/workflows/reusable_workflow_n.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0` 

## Related Issues

- N/A

## Review Hints

- Check org-infra [release v0.1.0](https://github.com/complytime/org-infra/tree/v0.1.0)
- Manually updated with SHA `baf5b2e21e61581b4a3a129795286e8592e6afbb`
