### PR TITLE
chore: bumps reusable workflows to v0.2.1

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   call_reusable_ci:
     name: Standardized CI
-    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     permissions:
       contents: read
       issues: read

--- a/.github/workflows/ci_crapload.yml
+++ b/.github/workflows/ci_crapload.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   crapload:
     name: CRAP Load Analysis
-    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     permissions:
       contents: read
 

--- a/.github/workflows/ci_dependencies.yml
+++ b/.github/workflows/ci_dependencies.yml
@@ -25,11 +25,11 @@ env:
 jobs:
   call_deps_reviewer:
     name: General
-    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
 
   call_dependabot_reviewer:
     name: Dependabot
-    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
 
   comment_on_dependabot_prs:
     name: Dependabot Comment

--- a/.github/workflows/ci_publish_ghcr.yml
+++ b/.github/workflows/ci_publish_ghcr.yml
@@ -56,7 +56,7 @@ jobs:
       security-events: write  # upload SARIF results
       id-token: write         # OIDC for registry auth
       actions: read           # access reusable workflow
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       enable_osv: true
       enable_trivy_source: true
@@ -76,7 +76,7 @@ jobs:
       id-token: write      # OIDC for registry auth
       actions: read        # access reusable workflow
       attestations: write  # publish build provenance
-    uses: complytime/org-infra/.github/workflows/reusable_publish_ghcr.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_publish_ghcr.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       component_name: beacon-distro
       containerfile_path: beacon-distro/Containerfile.collector
@@ -100,7 +100,7 @@ jobs:
       security-events: write  # upload SARIF results
       id-token: write         # OIDC for registry auth
       actions: read           # required by osv_scanner nested job
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       enable_osv: false
       enable_trivy_source: false
@@ -119,7 +119,7 @@ jobs:
     permissions:
       packages: write  # attach signature to image
       id-token: write  # OIDC for keyless signing
-    uses: complytime/org-infra/.github/workflows/reusable_sign_and_verify.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_sign_and_verify.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       image_name: ${{ needs.build-beacon-distro.outputs.image }}
       digest: ${{ needs.build-beacon-distro.outputs.digest }}

--- a/.github/workflows/ci_publish_quay.yml
+++ b/.github/workflows/ci_publish_quay.yml
@@ -80,7 +80,7 @@ jobs:
     needs: [setup, tag-ghcr]
     permissions:
       packages: read
-    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       source_registry: ghcr.io
       source_image: complytime/complybeacon-beacon-distro

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -18,4 +18,4 @@ jobs:
       actions: read           # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
       security-events: write  # Require writing security events to upload SARIF file to security tab
       id-token: write         # Needed to access GitHub's OIDC token which verifies the authenticity of the result when publishing it.
-    uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1

--- a/.github/workflows/ci_security.yml
+++ b/.github/workflows/ci_security.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write
       packages: write
       id-token: write
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       # OSV focuses on known CVEs in dependencies; Trivy adds broader coverage
       enable_trivy_source: true
@@ -35,4 +35,4 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    uses: complytime/org-infra/.github/workflows/reusable_security.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_security.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1

--- a/.github/workflows/ci_sonarcloud.yml
+++ b/.github/workflows/ci_sonarcloud.yml
@@ -42,7 +42,7 @@ jobs:
       contents: read
       pull-requests: read
     needs: generate-coverage
-    uses: complytime/org-infra/.github/workflows/reusable_sonarqube.yml@393ab96ded06d41472526fb46ebe7a7188c422d3 # v0.2.0
+    uses: complytime/org-infra/.github/workflows/reusable_sonarqube.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       sonar_organization: ${{ vars.SONAR_ORGANIZATION }}
       sonar_project_key: ${{ vars.SONAR_PROJECT_KEY }}


### PR DESCRIPTION
## Summary

This PR bumps the org-infra reusable workflows from `v0.2.0` to `v0.2.1` based on the [new release.](https://github.com/complytime/org-infra/releases/tag/v0.2.1)

## Related Issues

- N/A

## Review Hints

- Ensure matching SHA `cfd981e757253218aefb37c91969c32827e5c4b1` pinned to `# v0.2.1`
- On VS Code or text editor at `.github/workflows` directory scope use `Ctrl+F SHA + space # v0.2.1` and ensure consistent matches 
