### PR TITLE
fix(ci): add setup-go to SonarCloud workflow

### DIFF
--- a/.github/workflows/ci_sonarcloud.yml
+++ b/.github/workflows/ci_sonarcloud.yml
@@ -10,6 +10,9 @@ permissions:
   issues: none
   pull-requests: none
 
+env:
+  GO_VERSION: 1.25
+
 jobs:
   generate-coverage:
     name: Generate Coverage Report
@@ -17,6 +20,11 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "${{ env.GO_VERSION }}"
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0


### PR DESCRIPTION
## Summary

- Add `actions/setup-go@v6.4.0` to the `generate-coverage` job in `ci_sonarcloud.yml`
- Add `GO_VERSION: 1.25` env var, matching the pattern in `ci_local.yml`
- Fixes 21 consecutive SonarCloud failures since April 21

## Root Cause

The `ci_sonarcloud.yml` workflow was missing `actions/setup-go`. It relied on the Go version pre-installed on `ubuntu-latest`. When the modules' `toolchain go1.25.9` directive triggered an automatic toolchain download, the downloaded toolchain did not include `go tool covdata`, causing coverage generation to fail:

```
# github.com/complytime/complybeacon/proofwatch/cmd/validate-logs
go: no such tool "covdata"
```

All other workflows (`ci_local.yml`) already include `actions/setup-go` and are unaffected.
Found during testing: complytime-collector-components PR 229

Fixes #245

## Test plan

- [ ] Verify SonarCloud workflow passes on next push to `main` after merge
- [ ] Confirm coverage artifact is produced

Made with [Cursor](https://cursor.com)