### PR TITLE
refactor(ci): use dedicated trivy image scan workflow

### DIFF
--- a/.github/workflows/ci_publish_ghcr.yml
+++ b/.github/workflows/ci_publish_ghcr.yml
@@ -52,15 +52,12 @@ jobs:
     name: Pre-build Source Scan
     permissions:
       contents: read          # checkout source for scanning
-      packages: write         # reusable workflow's nested job requires write
       security-events: write  # upload SARIF results
-      id-token: write         # OIDC for registry auth
       actions: read           # access reusable workflow
     uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       enable_osv: true
       enable_trivy_source: true
-      enable_trivy_image: false
       trivy_severity: HIGH,CRITICAL
     secrets: inherit
 
@@ -95,16 +92,11 @@ jobs:
     name: Scan Beacon Distro Image
     needs: [build-beacon-distro]
     permissions:
-      contents: read          # reusable may checkout for config
-      packages: write         # pull image from GHCR
+      packages: write         # push attestation to registry
       security-events: write  # upload SARIF results
-      id-token: write         # OIDC for registry auth
-      actions: read           # required by osv_scanner nested job
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
+      id-token: write         # keyless signing of attestation
+    uses: complytime/org-infra/.github/workflows/reusable_trivy_image_scan.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
-      enable_osv: false
-      enable_trivy_source: false
-      enable_trivy_image: true
       image_ref: ${{ needs.build-beacon-distro.outputs.image }}:sha-${{ github.sha }}
       image_digest: ${{ needs.build-beacon-distro.outputs.digest }}
       trivy_severity: HIGH,CRITICAL


### PR DESCRIPTION
## Summary

Switch the `scan-image-beacon-distro` stage from `reusable_vuln_scan.yml` to the new
`reusable_trivy_image_scan.yml` which was extracted in org-infra to avoid forcing
elevated permissions (`packages: write`, `id-token: write`) on callers that only
need source/dependency scanning.

Changes to `ci_publish_ghcr.yml`:
- **scan-source**: removed `packages: write`, `id-token: write`, and `enable_trivy_image` input (no longer needed after the trivy_image job was extracted from the reusable workflow)
- **scan-image-beacon-distro**: switched to `reusable_trivy_image_scan.yml`, removed `enable_osv`/`enable_trivy_source`/`enable_trivy_image` inputs, trimmed permissions to only what the image scan job needs

## Related Issues

- Depends on: complytime/org-infra#290
- Fixes startup failure in [complytime/.github Security Checks](https://github.com/complytime/.github/actions/runs/26514040649)

## Review Hints

- This PR is a **draft** and must remain so until complytime/org-infra#290 is merged and tagged. The pinned SHA in the `uses:` directives must be updated to the new release SHA before merging.

- The diff is small (3 insertions, 11 deletions). Review the permission trimming on `scan-source` and the workflow switch on `scan-image-beacon-distro` together.

- The pipeline flow is unchanged: `scan-source -> build-beacon-distro -> scan-image-beacon-distro -> sign-beacon-distro -> summary`. Only the reusable workflow reference and its inputs changed in stages 1 and 3.