### PR TITLE
ci: rename Quay destination to complytime/beacon-collector

### DIFF
--- a/.github/workflows/ci_local.yml
+++ b/.github/workflows/ci_local.yml
@@ -46,7 +46,7 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1
         with:
           version: 3.x
           repo-token: ${{ github.token }}
@@ -108,7 +108,7 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1
         with:
           version: 3.x
           repo-token: ${{ github.token }}
@@ -138,7 +138,7 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1
         with:
           version: 3.x
           repo-token: ${{ github.token }}
@@ -173,7 +173,7 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1
         with:
           version: 3.x
           repo-token: ${{ github.token }}
@@ -252,7 +252,7 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1
         with:
           version: 3.x
           repo-token: ${{ github.token }}

--- a/.github/workflows/ci_publish_ghcr.yml
+++ b/.github/workflows/ci_publish_ghcr.yml
@@ -233,7 +233,7 @@ jobs:
           go-version: "1.26"
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1
         with:
           version: 3.x
           repo-token: ${{ github.token }}

--- a/.github/workflows/ci_publish_quay.yml
+++ b/.github/workflows/ci_publish_quay.yml
@@ -86,8 +86,10 @@ jobs:
       source_image: complytime/complybeacon-beacon-distro
       source_tag: ${{ needs.setup.outputs.source_tag }}
       dest_registry: quay.io
-      dest_image: continuouscompliance/complytime-beacon-distro
+      dest_image: complytime/beacon-collector
       dest_tag: ${{ needs.setup.outputs.dest_tag }}
+      additional_tags: latest
+      include_sha_tags: true
       allowed_identity_regex: https://github.com/complytime/org-infra(/.*)?
       fail_if_dest_exists: ${{ inputs.force != true }}
     secrets:

--- a/.github/workflows/ci_sonarcloud.yml
+++ b/.github/workflows/ci_sonarcloud.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_version_sync.yml
+++ b/.github/workflows/ci_version_sync.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/publish_image/publish_image.md
+++ b/docs/publish_image/publish_image.md
@@ -166,9 +166,9 @@ For pull requests from organization members, the same security pipeline runs to 
   ║  │  │     ✓ Verify source signature                                 │  │  ║
   ║  │  │                                                               │  │  ║
   ║  │  │  3. cosign copy (preserves all signatures + attestations)     │  │  ║
-  ║  │  │     ghcr.io/org/image@sha256:... → quay.io/org/image:v1.2.3   │  │  ║
+  ║  │  │     ghcr.io/org/image → quay.io/complytime/beacon-collector    │  │  ║
   ║  │  │                                                               │  │  ║
-  ║  │  │  4. Apply semver tags: v1.2.3, sha-<full>, and sha-<short>    │  │  ║
+  ║  │  │  4. Apply tags: v1.2.3, latest, sha-<full>, sha-<short>      │  │  ║
   ║  │  │                                                               │  │  ║
   ║  │  │  5. Post-promotion verification (destination registry)        │  │  ║
   ║  │  └───────────────────────────────────────────────────────────────┘  │  ║
@@ -180,7 +180,8 @@ For pull requests from organization members, the same security pipeline runs to 
                                       ▼
                       ┌───────────────────────────────┐
                       │  ✅ Production Image Ready    │
-                      │  quay.io/org/image:v1.2.3    │
+                      │  quay.io/complytime/         │
+                      │    beacon-collector:v1.2.3   │
                       │  (all with preserved certs)  │
                       └───────────────────────────────┘
 ```
@@ -376,7 +377,7 @@ cosign verify ghcr.io/complytime/complybeacon-beacon-distro:dev-pr123 \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 
 # Verify Quay image (production release)
-cosign verify quay.io/continuouscompliance/complytime-beacon-distro:v1.2.3 \
+cosign verify quay.io/complytime/beacon-collector:v1.2.3 \
   --certificate-identity-regexp='https://github.com/complytime/.*' \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 ```
@@ -436,7 +437,7 @@ skopeo inspect docker://ghcr.io/complytime/complybeacon-beacon-distro:sha-abc123
 |--------------------------------------|-------------------------------------------------------------------|---------------------------|----------------------------------|
 | Build & publish to GHCR (production) | [`ci_publish_ghcr.yml`](../.github/workflows/ci_publish_ghcr.yml) | Push to `main` (after CI) | `sha-<commit>`                   |
 | Build & publish to GHCR (dev)        | [`ci_publish_ghcr.yml`](../.github/workflows/ci_publish_ghcr.yml) | PR from org member        | `dev-pr<number>`, `sha-<commit>` |
-| Promote to Quay.io                   | [`ci_publish_quay.yml`](../.github/workflows/ci_publish_quay.yml) | Push tag `v*.*.*`         | `v1.2.3`, `sha-<commit>`         |
+| Promote to Quay.io                   | [`ci_publish_quay.yml`](../.github/workflows/ci_publish_quay.yml) | Push tag `v*.*.*`         | `v1.2.3`, `latest`, `sha-<commit>` |
 
 **Verification Commands:**
 


### PR DESCRIPTION
Migrate from legacy continuouscompliance org to complytime namespace. Add latest tag and SHA tags for cross-registry traceability.

Fixes: #243