### PR TITLE
ci: bump Go version to 1.26 in SonarCloud workflow

### DIFF
--- a/.github/workflows/ci_sonarcloud.yml
+++ b/.github/workflows/ci_sonarcloud.yml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: none
 
 env:
-  GO_VERSION: 1.25
+  GO_VERSION: 1.26
 
 jobs:
   generate-coverage:


### PR DESCRIPTION
Update GO_VERSION from 1.25 to 1.26 in ci_sonarcloud.yml to align with the project's Go 1.26 toolchain.