### PR TITLE
feat: add release-prep validation script and initial changelog

### DIFF
--- a/.taskfiles/dev.yml
+++ b/.taskfiles/dev.yml
@@ -81,3 +81,10 @@ tasks:
       - task: mega-lint
         vars:
           APPLY_FIXES: "all"
+
+  release-prep:
+    desc: "Validate release readiness (VERSION=x.y.z, e.g. task dev:release-prep VERSION=0.1.0)"
+    requires:
+      vars: [VERSION]
+    cmds:
+      - bash {{.ROOT_DIR}}/.taskfiles/scripts/release-prep.sh {{.VERSION}}

--- a/.taskfiles/scripts/release-prep.sh
+++ b/.taskfiles/scripts/release-prep.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# Pre-release validation: checks that the project is ready to tag a release.
+# Usage: release-prep.sh <version>   (e.g. release-prep.sh 0.1.0)
+# Exit 0 = ready to tag, exit 1 = issues found.
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+	echo "Usage: release-prep.sh <version>  (without 'v' prefix, e.g. 0.1.0)"
+	exit 1
+fi
+
+# Strip leading 'v' if the caller accidentally included it
+VERSION="${VERSION#v}"
+
+# Validate semver format (major.minor.patch, no pre-release/build metadata)
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo "ERROR: '$VERSION' is not a valid semver (expected x.y.z)"
+	exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+FAILED=0
+
+echo "=== Release prep check for v${VERSION} ==="
+echo ""
+
+# ── 1. Check that the tag does not already exist ────────────────
+echo "--- Tag collision ---"
+if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+	echo "  FAIL: Tag v${VERSION} already exists"
+	FAILED=1
+else
+	echo "  OK: Tag v${VERSION} does not exist yet"
+fi
+
+# ── 2. Check proofwatch.Version() ───────────────────────────────
+echo "--- proofwatch.Version() ---"
+PW_FILE="proofwatch/proofwatch.go"
+if [[ -f "$PW_FILE" ]]; then
+	PW_VERSION=$(grep -oP 'return\s+"\K[0-9]+\.[0-9]+\.[0-9]+' "$PW_FILE" || true)
+	if [[ "$PW_VERSION" == "$VERSION" ]]; then
+		echo "  OK: proofwatch.Version() returns \"${VERSION}\""
+	else
+		echo "  FAIL: proofwatch.Version() returns \"${PW_VERSION}\" (expected \"${VERSION}\")"
+		FAILED=1
+	fi
+else
+	echo "  WARN: $PW_FILE not found, skipping"
+fi
+
+# ── 3. Check Containerfile IMAGE_VERSION ARG ────────────────────
+echo "--- Containerfile IMAGE_VERSION ---"
+CF="beacon-distro/Containerfile.collector"
+if [[ -f "$CF" ]]; then
+	CF_VERSION=$(grep -oP '^ARG IMAGE_VERSION=\K.*' "$CF" || true)
+	if [[ "$CF_VERSION" == "$VERSION" ]]; then
+		echo "  OK: ${CF} ARG IMAGE_VERSION=${VERSION}"
+	elif [[ -z "$CF_VERSION" ]]; then
+		echo "  FAIL: ${CF} is missing ARG IMAGE_VERSION"
+		echo "  ACTION: Add 'ARG IMAGE_VERSION=${VERSION}' before the LABEL block in ${CF}"
+		FAILED=1
+	else
+		# ARG exists but with wrong version — update in place
+		sed -i "s/^ARG IMAGE_VERSION=.*/ARG IMAGE_VERSION=${VERSION}/" "$CF"
+		echo "  FIXED: Updated ARG IMAGE_VERSION to ${VERSION} in ${CF}"
+	fi
+else
+	echo "  WARN: $CF not found, skipping"
+fi
+
+# ── 4. Check CHANGELOG.md ───────────────────────────────────────
+echo "--- CHANGELOG.md ---"
+CL="CHANGELOG.md"
+TODAY=$(date +%Y-%m-%d)
+if [[ ! -f "$CL" ]]; then
+	echo "  CHANGELOG.md not found, creating with template..."
+	cat >"$CL" <<-TEMPLATE
+		# Changelog
+
+		All notable changes to this project will be documented in this file.
+
+		The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+		and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+		## [${VERSION}] - ${TODAY}
+
+		### Added
+
+		- TODO: describe new features
+
+		### Changed
+
+		- TODO: describe changes to existing functionality
+
+		### Fixed
+
+		- TODO: describe bug fixes
+	TEMPLATE
+	# Dedent the heredoc (written with leading tabs for readability)
+	sed -i 's/^\t//' "$CL"
+	echo "  CREATED: $CL with template for ${VERSION}"
+	echo "  ACTION: Fill in the changelog entries, then re-run this check"
+	FAILED=1
+elif grep -qP "## \[?${VERSION}\]?" "$CL"; then
+	# Entry exists — check for unfilled TODO placeholders
+	if sed -n "/## \[${VERSION}\]/,/^## /p" "$CL" | grep -q 'TODO:'; then
+		echo "  WARN: CHANGELOG.md has an entry for ${VERSION} but contains TODO placeholders"
+		FAILED=1
+	else
+		echo "  OK: CHANGELOG.md has an entry for ${VERSION}"
+	fi
+else
+	# File exists but no entry for this version — insert template after the header
+	echo "  No entry for ${VERSION}, adding template..."
+	TEMPLATE=$(
+		cat <<-EOF
+
+			## [${VERSION}] - ${TODAY}
+
+			### Added
+
+			- TODO: describe new features
+
+			### Changed
+
+			- TODO: describe changes to existing functionality
+
+			### Fixed
+
+			- TODO: describe bug fixes
+		EOF
+	)
+	# Dedent the template (strip one leading tab per line)
+	TEMPLATE="${TEMPLATE#$'\t'}"          # strip leading tab on first line
+	TEMPLATE="${TEMPLATE//$'\n\t'/$'\n'}" # strip leading tab on remaining lines
+
+	# Insert after the first header line (# Changelog or similar)
+	# If there's an [Unreleased] section, insert before it; otherwise after line 1
+	if grep -qn '## \[Unreleased\]' "$CL"; then
+		# Insert after the [Unreleased] section header
+		UNRELEASED_LINE=$(grep -n '## \[Unreleased\]' "$CL" | head -1 | cut -d: -f1)
+		# Find the next ## heading after Unreleased (that's where we insert before)
+		NEXT_HEADING=$(tail -n "+$((UNRELEASED_LINE + 1))" "$CL" | grep -n '^## ' | head -1 | cut -d: -f1)
+		if [[ -n "$NEXT_HEADING" ]]; then
+			INSERT_LINE=$((UNRELEASED_LINE + NEXT_HEADING - 1))
+		else
+			# No next heading — append after Unreleased content
+			INSERT_LINE=$(wc -l <"$CL")
+		fi
+		head -n "$INSERT_LINE" "$CL" >"${CL}.tmp"
+		echo "$TEMPLATE" >>"${CL}.tmp"
+		tail -n "+$((INSERT_LINE + 1))" "$CL" >>"${CL}.tmp"
+		mv "${CL}.tmp" "$CL"
+	else
+		# No Unreleased section — insert after the first line
+		head -n 1 "$CL" >"${CL}.tmp"
+		echo "$TEMPLATE" >>"${CL}.tmp"
+		tail -n +2 "$CL" >>"${CL}.tmp"
+		mv "${CL}.tmp" "$CL"
+	fi
+	echo "  ADDED: Template entry for ${VERSION} in $CL"
+	echo "  ACTION: Fill in the changelog entries, then re-run this check"
+	FAILED=1
+fi
+
+# ── 5. Run dependency version check ─────────────────────────────
+echo "--- Dependency version alignment ---"
+if bash "${ROOT_DIR}/.taskfiles/scripts/version-check.sh" >/dev/null 2>&1; then
+	echo "  OK: Go and OTel versions are aligned"
+else
+	echo "  FAIL: Dependency version drift detected (run 'task version:check' for details)"
+	FAILED=1
+fi
+
+# ── 6. Check that HEAD is on main ───────────────────────────────
+echo "--- Branch check ---"
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+if [[ "$CURRENT_BRANCH" == "main" ]]; then
+	echo "  OK: On branch main"
+else
+	echo "  WARN: On branch '${CURRENT_BRANCH}' (releases should be tagged from main)"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────
+echo ""
+if [[ "$FAILED" -eq 0 ]]; then
+	echo "All checks passed. Ready to tag:"
+	echo "  git tag -s v${VERSION} -m \"Release v${VERSION}\""
+	echo "  git push origin v${VERSION}"
+else
+	echo "Some checks failed. Fix the issues above before tagging."
+	exit 1
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,20 @@ All S3 environment variables have inline defaults that target rustfs. The stack 
 
 All commits MUST use Conventional Commits, the `-s` flag (Signed-off-by), and include an `Assisted-by` trailer when AI-assisted. See `.specify/memory/constitution.md` for full details.
 
+## Changelog
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. The audience is **users and adopting developers**, not contributors or CI.
+
+**Principles:**
+
+- Write entries that answer "what can I do now?" or "what changed for me?", not "what did we refactor internally?"
+- Group by component scope (`proofwatch`, `truthbeam`, `beacon-distro`) when an entry is module-specific
+- Use descriptive, multi-line entries that give enough context for someone unfamiliar with the codebase to understand the value — avoid terse one-liners that require reading source to interpret
+- Internal tooling changes (CI actions, linter upgrades, dependency bumps, code quality tooling) are **not** changelog entries unless they affect the user experience or public API
+- Do not use `BREAKING` labels until there is a prior release to break against
+- `Changed` and `Removed` sections only apply when a released feature is modified or dropped — pre-release iteration is not a "change"
+- Reference PR numbers only when they add traceability for significant features
+
 ## Integration Test Gotchas
 
 - **RustFS is not MinIO**: The health endpoint is `/health`, not `/minio/health/live` (returns 403). The S3 API is compatible but administrative endpoints differ. The `rustfs-init` container uses `rc` (RustFS CLI), not `mc` (MinIO client).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,16 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+> The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **proofwatch** library for collecting compliance evidence and emitting it as OpenTelemetry logs. Supports TLS-secured collector connections. Exposes OTel metrics counters that track evidence volume per control.
+- **truthbeam** OTel Collector processor that enriches evidence logs with compliance metadata from an external enrichment service. Response caching and TLS enabled by default.
+- **beacon-distro** pre-built OTel Collector distribution (UBI10 Micro container) bundling proofwatch, truthbeam, the AWS S3 exporter, OIDC and bearer token auth extensions, and OpenAPI request validation. Container images are cosign-signed with SBOM attestation and published to `ghcr.io` and `quay.io`.
+- Compliance attribute model defined as OTel Weaver semantic conventions, with generated Go constants and Markdown attribute reference docs. Attributes match the Gemara v1 evidence schema and OCSF activity structure.
+- AWS S3 evidence export with automatic partitioning by `policy.rule.id`. Evidence for each compliance rule lands in its own prefix for straightforward audit retrieval.
+- Local development stack (`task infra:deploy`) running the full evidence pipeline via podman-compose: Loki for log aggregation, the beacon collector, RustFS for S3-compatible object storage, and Grafana with a pre-provisioned evidence dashboard. Works out of the box on Linux (including SELinux/RHEL) with no cloud credentials required.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -78,6 +78,13 @@ tasks:
     cmds:
       - task: infra:build
 
+  release-prep:
+    desc: "Validate release readiness (VERSION=x.y.z)"
+    cmds:
+      - task: dev:release-prep
+        vars:
+          VERSION: "{{.VERSION | default .CLI_ARGS}}"
+
   check:
     desc: Run all quality gates
     deps: [lint, test]

--- a/beacon-distro/Containerfile.collector
+++ b/beacon-distro/Containerfile.collector
@@ -21,13 +21,17 @@ RUN --mount=type=cache,target=/root/.cache/go-build builder --config manifest.ya
 # Using UBI10 Micro (minimal runtime base, similar to distroless)
 FROM registry.access.redhat.com/ubi10/ubi-micro@sha256:1983e3d2fa54a1afedf015ad4d8f9cfaeed15182d9cf532e5cb35de2c1bda580
 
+# Image version — updated by `task release-prep`, overridable via --build-arg
+ARG IMAGE_VERSION=0.1.0
+
 # Metadata labels following OCI Image Format Specification
 # Consolidated into single LABEL instruction to minimize layers
 LABEL org.opencontainers.image.title="ComplyBeacon Collector" \
       org.opencontainers.image.description="OpenTelemetry collector distribution for compliance evidence collection" \
       org.opencontainers.image.vendor="ComplyTime" \
       org.opencontainers.image.source="https://github.com/complytime/complybeacon" \
-      org.opencontainers.image.licenses="Apache-2.0"
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${IMAGE_VERSION}"
 
 # Run as non-root user for security
 # USER_UID can be overridden at build time if needed

--- a/docs/publish_image/publish_image.md
+++ b/docs/publish_image/publish_image.md
@@ -6,7 +6,7 @@ This guide explains how to publish in GHCR and promote in Quay for container ima
 
 The publishing process values **security and automation** to provide predictable, low-cost image releases.
 
-```
+```text
 Main Branch Push  →  Build + Scan + Sign  →  GHCR (sha-<commit>)
                                               ↓
 Release Tag (v*)  →  Verify + Promote     →  Quay.io (v1.2.3)
@@ -23,7 +23,7 @@ PR from Org Member  →  Build + Scan + Sign  →  GHCR (dev-pr<number>)
 
 ## Main Branch Pipeline (Scan Source → Build → Scan Image → Sign)
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────────┐
 │                              MAIN BRANCH PUSH                                   │
 └─────────────────────────────────────────────────────────────────────────────────┘
@@ -104,7 +104,7 @@ PR from Org Member  →  Build + Scan + Sign  →  GHCR (dev-pr<number>)
 
 For pull requests from organization members, the same security pipeline runs to validate Containerfile changes before merge.
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────────┐
 │                       PULL REQUEST (from org member)                            │
 └─────────────────────────────────────────────────────────────────────────────────┘
@@ -149,7 +149,7 @@ For pull requests from organization members, the same security pipeline runs to 
 
 ## Release Pipeline (Promote to Production)
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────────┐
 │                        RELEASE TAG PUSH (v1.2.3)                                │
 └─────────────────────────────────────────────────────────────────────────────────┘
@@ -249,16 +249,74 @@ Promotion copies signed images from GHCR to Quay.io for public distribution.
 
 > **Key Point:** Promotion does **not rebuild** the image. It uses `cosign copy` to transfer the exact same bytes (identical `sha256` digest) from GHCR to Quay, preserving all signatures and attestations. This guarantees the image you tested in GHCR is identical to what's released on Quay.
 
+### Pre-Release Checklist
+
+Before tagging a release, run through these steps to ensure everything is aligned.
+You can automate most of this with `task dev:release-prep`.
+
+1. **Verify CI is green on `main`.**
+   Check that the latest commit on `main` passed all CI checks (lint, test, version sync,
+   security scans) and that a signed image exists on GHCR for the HEAD commit.
+
+2. **Verify `proofwatch.Version()` matches the intended release version.**
+   The version constant lives in `proofwatch/proofwatch.go`. If the intended release is
+   `v0.2.0`, the function must return `"0.2.0"`. Update and merge before tagging.
+
+3. **Verify `IMAGE_VERSION` in the Containerfile matches the release version.**
+   The `ARG IMAGE_VERSION=` default in `beacon-distro/Containerfile.collector` must match
+   the release version (without the `v` prefix). `task release-prep` updates this
+   automatically. CI can also override it via `--build-arg IMAGE_VERSION=x.y.z`.
+
+4. **Verify `CHANGELOG.md` has an entry for this version.**
+   At minimum, include a summary of notable changes since the last release (or since
+   project inception for `v0.1.0`). Follow [Keep a Changelog](https://keepachangelog.com/)
+   format.
+
+5. **Verify dependency versions are aligned.**
+   Run `task version:check` to confirm Go and OTel dependency versions are consistent
+   across all modules, Containerfiles, CI workflows, and docs.
+
+6. **Run `task check` locally.**
+   This runs all quality gates (lint + test) against your local checkout.
+
 ### Creating a Release
 
+After the pre-release checklist passes:
+
 ```bash
-# Ensure your changes are merged to main and images are built
 git checkout main
 git pull origin main
+
+# Confirm the GHCR image exists for HEAD
+skopeo inspect docker://ghcr.io/complytime/complybeacon-beacon-distro:sha-$(git rev-parse --short HEAD)
 
 # Create a signed tag
 git tag -s v1.2.3 -m "Release v1.2.3"
 git push origin v1.2.3
+```
+
+Pushing the tag triggers `ci_publish_quay.yml`, which looks up the `sha-<commit>` image
+already on GHCR and promotes it to `quay.io/complytime/beacon-collector` with the version
+tag, `latest`, and SHA tags. No rebuild occurs -- the promoted image has the exact same
+`sha256` digest as the GHCR source.
+
+### Post-Release Verification
+
+After the Quay promotion workflow completes:
+
+```bash
+# Verify the image landed on Quay
+skopeo inspect docker://quay.io/complytime/beacon-collector:v1.2.3
+
+# Verify signature on the promoted image
+cosign verify quay.io/complytime/beacon-collector:v1.2.3 \
+  --certificate-identity-regexp='https://github.com/complytime/.*' \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+
+# Confirm digests match between GHCR source and Quay destination
+GHCR_DIGEST=$(skopeo inspect docker://ghcr.io/complytime/complybeacon-beacon-distro:sha-$(git rev-parse --short HEAD) --format "{{.Digest}}")
+QUAY_DIGEST=$(skopeo inspect docker://quay.io/complytime/beacon-collector:v1.2.3 --format "{{.Digest}}")
+[ "$GHCR_DIGEST" = "$QUAY_DIGEST" ] && echo "Digests match" || echo "MISMATCH - investigate"
 ```
 
 ### Release Cadence
@@ -433,10 +491,10 @@ skopeo inspect docker://ghcr.io/complytime/complybeacon-beacon-distro:sha-abc123
 
 ## Quick Reference
 
-| Task                                 | Workflow                                                          | Trigger                   | Tags                             |
-|--------------------------------------|-------------------------------------------------------------------|---------------------------|----------------------------------|
-| Build & publish to GHCR (production) | [`ci_publish_ghcr.yml`](../.github/workflows/ci_publish_ghcr.yml) | Push to `main` (after CI) | `sha-<commit>`                   |
-| Build & publish to GHCR (dev)        | [`ci_publish_ghcr.yml`](../.github/workflows/ci_publish_ghcr.yml) | PR from org member        | `dev-pr<number>`, `sha-<commit>` |
+| Task                                 | Workflow                                                          | Trigger                   | Tags                               |
+|--------------------------------------|-------------------------------------------------------------------|---------------------------|------------------------------------|
+| Build & publish to GHCR (production) | [`ci_publish_ghcr.yml`](../.github/workflows/ci_publish_ghcr.yml) | Push to `main` (after CI) | `sha-<commit>`                     |
+| Build & publish to GHCR (dev)        | [`ci_publish_ghcr.yml`](../.github/workflows/ci_publish_ghcr.yml) | PR from org member        | `dev-pr<number>`, `sha-<commit>`   |
 | Promote to Quay.io                   | [`ci_publish_quay.yml`](../.github/workflows/ci_publish_quay.yml) | Push tag `v*.*.*`         | `v1.2.3`, `latest`, `sha-<commit>` |
 
 **Verification Commands:**


### PR DESCRIPTION
Establishes the release process for v0.1.0: automated pre-tag validation and the project's first changelog.

- Add release-prep.sh and `task release-prep` target that validates tag uniqueness, proofwatch version string, Containerfile IMAGE_VERSION, changelog entries, dependency alignment, and branch state
- Add IMAGE_VERSION build arg to Containerfile.collector, wired into the OCI version label
- Populate CHANGELOG.md with Keep a Changelog structure and entries for proofwatch, truthbeam, beacon-distro, attribute model, S3 export, and the local dev stack
- Document changelog conventions in AGENTS.md
- Expand publish_image.md with pre-release checklist, post-release verification, and Quay promotion workflow