### PR TITLE
fix(ci): match Quay workflow reference to actual upstream filename

### DIFF
--- a/.github/workflows/ci_publish_quay.yml
+++ b/.github/workflows/ci_publish_quay.yml
@@ -80,7 +80,7 @@ jobs:
     needs: [setup, tag-ghcr]
     permissions:
       packages: read
-    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
+    uses: complytime/org-infra/.github/workflows/resuable_publish_quay.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
     with:
       source_registry: ghcr.io
       source_image: complytime/complybeacon-beacon-distro


### PR DESCRIPTION
The publish workflow in complytime/org-infra is named `resuable_publish_quay.yml` (transposed 'a' and 'u').

Note: This will need to be fixed when complytime/org-infra#292 is resolved.