### PR TITLE
fix(ci): increase GHCR prune retention to prevent Quay promotion failures

### DIFF
--- a/.github/workflows/ci_prune_ghcr.yml
+++ b/.github/workflows/ci_prune_ghcr.yml
@@ -55,5 +55,5 @@ jobs:
         with:
           package-name: complybeacon-beacon-distro
           package-type: container
-          min-versions-to-keep: 10
+          min-versions-to-keep: 100
           ignore-versions: "^v"


### PR DESCRIPTION
The v0.1.0 release failed during Quay promotion because `cosign copy` could not find a referrer artifact that had been pruned from GHCR.

Root cause: `actions/delete-package-versions` with `min-versions-to-keep: 10` counts cosign artifacts (signatures, SLSA provenance, SBOM, vuln attestations) as separate package versions. Each successful build produces ~6 versions, so 10 retained versions covers fewer than 2 builds. The prune job, which runs after every GHCR publish, deleted cosign artifacts from the current build before the tag-triggered Quay promotion could run `cosign copy` to transfer them.

Raise `min-versions-to-keep` to 100 (~16 builds of headroom) as an interim fix. The structural fix is to replace `cosign copy` with `crane copy` + fresh `cosign sign` in the upstream reusable workflow (complytime/org-infra resuable_publish_quay.yml), eliminating the dependency on GHCR artifact survival between build and release.

Failed run: https://github.com/complytime/complytime-collector-components/actions/runs/26988690271/job/79644767853