### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo.
+* @complytime/complytime-dev


### PR DESCRIPTION
## Summary

Add CODEOWNERS file to ensure pull request reviews are requested from the appropriate team.

## Related Issues

- Identified during safe-settings adoption (complytime/.github#114)

## Review Hints

- Single file addition: `.github/CODEOWNERS`
- Default owner: `@complytime/complytime-dev`
