### PR TITLE
fix(ci): stop creating redundant sha-* tags on Quay

### DIFF
--- a/.github/workflows/ci_publish_ghcr.yml
+++ b/.github/workflows/ci_publish_ghcr.yml
@@ -247,7 +247,7 @@ jobs:
       dest_registry: quay.io
       dest_image: complytime/beacon-collector
       dest_tag: unstable
-      include_sha_tags: true
+      include_sha_tags: false
       allowed_identity_regex: https://github.com/complytime/org-infra(/.*)?
       fail_if_dest_exists: false
     secrets:

--- a/.github/workflows/ci_publish_quay.yml
+++ b/.github/workflows/ci_publish_quay.yml
@@ -152,7 +152,7 @@ jobs:
       dest_image: complytime/beacon-collector
       dest_tag: ${{ needs.setup.outputs.dest_tag }}
       additional_tags: latest
-      include_sha_tags: true
+      include_sha_tags: false
       allowed_identity_regex: https://github.com/complytime/org-infra(/.*)?
       fail_if_dest_exists: ${{ inputs.force != true }}
     secrets:


### PR DESCRIPTION
Disable include_sha_tags in both Quay promotion workflows. Every promotion was creating two extra tags (full and short SHA) that accumulated with each main push and release. This traceability is already provided by GHCR tags, image digests, and cosign signatures — duplicating it on Quay added clutter without value.

Assisted-by: Claude <noreply@anthropic.com>