### PR TITLE
fix(ci): correct reusable workflow filename after upstream rename

### DIFF
--- a/.github/workflows/ci_publish_ghcr.yml
+++ b/.github/workflows/ci_publish_ghcr.yml
@@ -238,8 +238,7 @@ jobs:
     permissions:
       packages: read # pull source image from GHCR
       id-token: write # OIDC for keyless cosign signing on destination
-    # upstream filename is misspelled (resuable); do not "fix" or the reference will 404
-    uses: complytime/org-infra/.github/workflows/resuable_publish_quay.yml@61946c7f0540ae774a049b0b83c6a9c026ff3968 # unstable
+    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@61946c7f0540ae774a049b0b83c6a9c026ff3968 # unstable
     with:
       source_registry: ghcr.io
       source_image: complytime/complybeacon-beacon-distro

--- a/.github/workflows/ci_publish_quay.yml
+++ b/.github/workflows/ci_publish_quay.yml
@@ -142,8 +142,7 @@ jobs:
     permissions:
       packages: read # pull source image from GHCR
       id-token: write # OIDC for keyless cosign signing on destination
-    # upstream filename is misspelled (resuable); do not "fix" or the reference will 404
-    uses: complytime/org-infra/.github/workflows/resuable_publish_quay.yml@61946c7f0540ae774a049b0b83c6a9c026ff3968 # unstable
+    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@61946c7f0540ae774a049b0b83c6a9c026ff3968 # unstable
     with:
       source_registry: ghcr.io
       source_image: complytime/complybeacon-beacon-distro


### PR DESCRIPTION
The org-infra repo renamed resuable_publish_quay.yml to
reusable_publish_quay.yml, fixing the original typo. Dependabot
bumped the SHA but kept the old filename, causing startup_failure
on every workflow that references it — including ci_local.yml
(via ci_publish_ghcr.yml) and ci_publish_quay.yml.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
