### PR TITLE
fix(ci): use reusable_trivy_image_scan for container image scanning

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -16,11 +16,11 @@ permissions:
 jobs:
   call_reusable_ci:
     name: Standardized CI
-    # TODO: Need the fixes in a later version. Reset when the next tag is cut.
-    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@61946c7f0540ae774a049b0b83c6a9c026ff3968 # unstable
+    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@bbd7194995388f96dd28c0c0792d406c8a249140 # v0.4.0
     permissions:
       contents: read
       issues: read
+      pull-requests: read
     # Image publishing is handled exclusively by ci_local.yml, which gates
     # the publish step behind all quality checks (lint, test, codegen verify,
     # integration tests). Duplicating it here caused redundant builds.

--- a/.github/workflows/ci_dependencies.yml
+++ b/.github/workflows/ci_dependencies.yml
@@ -25,11 +25,11 @@ env:
 jobs:
   call_deps_reviewer:
     name: General
-    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@2c193416adbc621a64021ace52bf57114d703888 # v0.3.1
+    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@bbd7194995388f96dd28c0c0792d406c8a249140 # v0.4.0
 
   call_dependabot_reviewer:
     name: Dependabot
-    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@2c193416adbc621a64021ace52bf57114d703888 # v0.3.1
+    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@bbd7194995388f96dd28c0c0792d406c8a249140 # v0.4.0
 
   comment_on_dependabot_prs:
     name: Dependabot Comment

--- a/.github/workflows/ci_publish_ghcr.yml
+++ b/.github/workflows/ci_publish_ghcr.yml
@@ -81,8 +81,7 @@ jobs:
       id-token: write # OIDC for registry auth
       actions: read # access reusable workflow
       attestations: write # publish build provenance
-    # zizmor:ignore ref-version-mismatch - Fix update for the job
-    uses: complytime/org-infra/.github/workflows/reusable_publish_ghcr.yml@2c193416adbc621a64021ace52bf57114d703888 # experimental
+    uses: complytime/org-infra/.github/workflows/reusable_publish_ghcr.yml@bbd7194995388f96dd28c0c0792d406c8a249140 # v0.4.0
     with:
       component_name: beacon-distro
       containerfile_path: beacon-distro/Containerfile.collector
@@ -123,7 +122,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════════════
   # STAGE 2: POST-BUILD IMAGE SCANNING
   # ═══════════════════════════════════════════════════════════════════════════
-  # Scans built images for OS package vulns, runtime deps, embedded secrets.
+  # Scans built images for OS package vulns and runtime deps.
   scan-image-beacon-distro:
     name: Scan Beacon Distro Image
     needs: [build-beacon-distro]
@@ -135,16 +134,12 @@ jobs:
       && needs.build-beacon-distro.result == 'success'
       && needs.build-beacon-distro.outputs.image != ''
     permissions:
-      contents: read # reusable may checkout for config
-      packages: write # pull image from GHCR
+      contents: read # reusable workflow checkout
+      packages: write # push vuln attestation to GHCR
       security-events: write # upload SARIF results
-      id-token: write # OIDC for registry auth
-      actions: read # required by osv_scanner nested job
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@2c193416adbc621a64021ace52bf57114d703888 # v0.3.1
+      id-token: write # keyless cosign attestation signing
+    uses: complytime/org-infra/.github/workflows/reusable_trivy_image_scan.yml@bbd7194995388f96dd28c0c0792d406c8a249140 # v0.4.0
     with:
-      enable_osv: false
-      enable_trivy_source: false
-      enable_trivy_image: true
       image_ref: ${{ needs.build-beacon-distro.outputs.image_ref }}
       image_digest: ${{ needs.build-beacon-distro.outputs.digest }}
       trivy_severity: HIGH,CRITICAL
@@ -166,7 +161,7 @@ jobs:
     permissions:
       packages: write # attach signature to image
       id-token: write # OIDC for keyless signing
-    uses: complytime/org-infra/.github/workflows/reusable_sign_and_verify.yml@2c193416adbc621a64021ace52bf57114d703888 # v0.3.1
+    uses: complytime/org-infra/.github/workflows/reusable_sign_and_verify.yml@bbd7194995388f96dd28c0c0792d406c8a249140 # v0.4.0
     with:
       image_name: ${{ needs.build-beacon-distro.outputs.image }}
       digest: ${{ needs.build-beacon-distro.outputs.digest }}
@@ -238,7 +233,7 @@ jobs:
     permissions:
       packages: read # pull source image from GHCR
       id-token: write # OIDC for keyless cosign signing on destination
-    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@61946c7f0540ae774a049b0b83c6a9c026ff3968 # unstable
+    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@bbd7194995388f96dd28c0c0792d406c8a249140 # v0.4.0
     with:
       source_registry: ghcr.io
       source_image: complytime/complybeacon-beacon-distro

--- a/.github/workflows/ci_publish_quay.yml
+++ b/.github/workflows/ci_publish_quay.yml
@@ -142,7 +142,7 @@ jobs:
     permissions:
       packages: read # pull source image from GHCR
       id-token: write # OIDC for keyless cosign signing on destination
-    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@61946c7f0540ae774a049b0b83c6a9c026ff3968 # unstable
+    uses: complytime/org-infra/.github/workflows/reusable_publish_quay.yml@bbd7194995388f96dd28c0c0792d406c8a249140 # v0.4.0
     with:
       source_registry: ghcr.io
       source_image: complytime/complybeacon-beacon-distro

--- a/.github/workflows/ci_security.yml
+++ b/.github/workflows/ci_security.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write
       packages: write
       id-token: write
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@2c193416adbc621a64021ace52bf57114d703888 # v0.3.1
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@bbd7194995388f96dd28c0c0792d406c8a249140 # v0.4.0
     with:
       # OSV focuses on known CVEs in dependencies; Trivy adds broader coverage
       enable_trivy_source: true
@@ -35,4 +35,4 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    uses: complytime/org-infra/.github/workflows/reusable_security.yml@2c193416adbc621a64021ace52bf57114d703888 # v0.3.1
+    uses: complytime/org-infra/.github/workflows/reusable_security.yml@bbd7194995388f96dd28c0c0792d406c8a249140 # v0.4.0


### PR DESCRIPTION
The org-infra v0.3.1 split image scanning out of reusable_vuln_scan.yml
into a dedicated reusable_trivy_image_scan.yml. The SHA bump in
ci_publish_ghcr.yml picked up the new vuln_scan (which no longer has
image scan inputs), causing startup_failure on every ci_local.yml and
ci_publish_ghcr.yml run since June 15.

Also drops the actions:read permission that was only needed for the
OSV scanner nested workflow call in the old vuln_scan workflow.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
