### PR TITLE
fix: remove gemara-content-service dependency from codegen and docs

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -137,7 +137,7 @@ err = pw.LogWithSeverity(ctx, evidence, olog.SeverityWarn)
 
 ### 4. Compass
 
-**Purpose**: A centralized lookup service that provides compliance context. It's the source of truth for mapping policies to standards and risk attributes. Compass is maintained as a separate project at [gemara-content-service](https://github.com/complytime/gemara-content-service) and is consumed here as a pre-built container image (`ghcr.io/complytime/gemara-content-service`).
+**Purpose**: A centralized lookup service that provides compliance context. It's the source of truth for mapping policies to standards and risk attributes. The OpenAPI client in `truthbeam/internal/client/` was originally generated from the `gemara-content-service` API spec (now archived at `complytime-labs`). The generated code is maintained as static source and the integration test suite uses a mock Compass server (`tests/integration/mock-compass/`).
 
 **Key Responsibilities**:
 * Receiving an EnrichmentRequest from `truthbeam`.

--- a/truthbeam/internal/client/codegen.go
+++ b/truthbeam/internal/client/codegen.go
@@ -1,3 +1,0 @@
-package client
-
-//go:generate go tool oapi-codegen --config=client-cfg.yaml https://raw.githubusercontent.com/complytime/gemara-content-service/main/api.yaml


### PR DESCRIPTION
## Summary

Minimal fix for the `gemara-content-service` archival. Removes the only two references to the external repository.

## Changes

- **Delete `truthbeam/internal/client/codegen.go`** — the `go:generate` directive fetches the API spec from `raw.githubusercontent.com/complytime/gemara-content-service/...`. After the repo transfer to `complytime-labs`, this URL returns 404. The generated client (`client.gen.go`) is already committed and self-contained — no runtime or build dependency on the upstream.

- **Update `docs/DESIGN.md`** — rewrite the Compass section to reflect that the OpenAPI client is maintained as static source and the upstream is archived.

## What this does NOT touch

Everything else continues to work unchanged:
- `client.gen.go` — stays, fully functional
- `truthbeam` processor — intact
- Integration tests — use mock-compass, unaffected
- Compose profiles — unchanged
- `api-codegen` task — becomes a silent no-op (cleanup tracked in #326)

Closes #325