### PR TITLE
chore: fix yamllint issues

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -17,10 +17,10 @@ jobs:
   call_reusable_ci:
     name: Standardized CI
     uses: complytime/org-infra/.github/workflows/reusable_ci.yml@638b2037394ca0f0b860a135c7c27dce75fd3c03 # v0.5.0
+    # Image publishing is handled exclusively by ci_local.yml, which gates
+    # the publish step behind all quality checks (lint, test, codegen verify,
+    # integration tests). Duplicating it here caused redundant builds.
     permissions:
       contents: read
       issues: read
       pull-requests: read
-    # Image publishing is handled exclusively by ci_local.yml, which gates
-    # the publish step behind all quality checks (lint, test, codegen verify,
-    # integration tests). Duplicating it here caused redundant builds.

--- a/.github/workflows/ci_publish_ghcr.yml
+++ b/.github/workflows/ci_publish_ghcr.yml
@@ -91,8 +91,8 @@ jobs:
       image_vendor: ComplyTime
       force_rebuild: ${{ inputs.force_rebuild || false }}
       allow_unprotected_ref: true # Allow workflow_dispatch on non-default branches
-    # NOTE: Outputs from the reusable workflow (image, digest, image_ref, tags)
-    # are automatically available to downstream jobs via needs.build-beacon-distro.outputs.*
+  # NOTE: Outputs from the reusable workflow (image, digest, image_ref, tags)
+  # are automatically available to downstream jobs via needs.build-beacon-distro.outputs.*
 
   # ═══════════════════════════════════════════════════════════════════════════
   # QUAY CREDENTIAL CHECK (for unstable promotion)

--- a/.taskfiles/infra.yml
+++ b/.taskfiles/infra.yml
@@ -80,7 +80,7 @@ tasks:
       - task: :version:sync
       - task: build
         vars:
-          { USE_GHCR_IMAGE: "{{.USE_GHCR_IMAGE}}", GHCR_TAG: "{{.GHCR_TAG}}" }
+          {USE_GHCR_IMAGE: "{{.USE_GHCR_IMAGE}}", GHCR_TAG: "{{.GHCR_TAG}}"}
       - |
         if [[ "{{.USE_GHCR_IMAGE}}" == "true" ]]; then
           echo "Using GHCR image: {{.GHCR_IMAGE}}:{{.GHCR_TAG}}"
@@ -114,4 +114,4 @@ tasks:
         vars:
           GHCR_TAG_INPUT: "{{.GHCR_TAG_INPUT}}"
       - task: :dev:test
-      - defer: { task: undeploy }
+      - defer: {task: undeploy}

--- a/.taskfiles/integration.yml
+++ b/.taskfiles/integration.yml
@@ -51,13 +51,13 @@ tasks:
           fi
     cmds:
       - task: validate-profile
-        vars: { PROFILE: "{{.PROFILE}}" }
+        vars: {PROFILE: "{{.PROFILE}}"}
         if: '[ -n "{{.PROFILE}}" ]'
       - task: ensure-certs
       - task: build-images
         vars:
           USE_GHCR_IMAGE: "{{.USE_GHCR_IMAGE}}"
-      - for: { var: PROFILES }
+      - for: {var: PROFILES}
         task: test-layer
         vars:
           PROFILE: "{{.ITEM}}"
@@ -153,7 +153,7 @@ tasks:
       - mkdir -p .test-output/integration/data && chmod 777 .test-output/integration/data
       - "{{.COMPOSE_CMD}} {{.COMPOSE_FILES}} {{.COMPOSE_PROFILES}} up -d"
       - task: wait
-        vars: { PROFILE: "{{.PROFILE}}", COMPOSE_FILES: "{{.COMPOSE_FILES}}" }
+        vars: {PROFILE: "{{.PROFILE}}", COMPOSE_FILES: "{{.COMPOSE_FILES}}"}
       - mkdir -p {{.GINKGO_OUTPUT_DIR}}
       - go tool ginkgo run {{.GINKGO_FLAGS}} --output-dir={{.GINKGO_OUTPUT_DIR}} --junit-report=junit-{{.PROFILE}}.xml {{.TEST_DIR}}
 
@@ -208,11 +208,11 @@ tasks:
     cmds:
       - task: ensure-certs
       - task: build-if-local
-        vars: { USE_GHCR_IMAGE: "{{.USE_GHCR_IMAGE}}" }
+        vars: {USE_GHCR_IMAGE: "{{.USE_GHCR_IMAGE}}"}
       - mkdir -p .test-output/integration/data && chmod 777 .test-output/integration/data
       - "{{.COMPOSE_CMD}} {{.COMPOSE_FILES}} {{.COMPOSE_PROFILES}} up -d --build"
       - task: wait
-        vars: { PROFILE: "{{.PROFILE}}", COMPOSE_FILES: "{{.COMPOSE_FILES}}" }
+        vars: {PROFILE: "{{.PROFILE}}", COMPOSE_FILES: "{{.COMPOSE_FILES}}"}
       - cmd: 'echo "Stack running. Run tests with: GOWORK=off go tool ginkgo run -vv {{.TEST_DIR}}"'
       - cmd: 'echo "Tear down with: task integration:down"'
 
@@ -231,7 +231,7 @@ tasks:
       - test "{{.USE_GHCR_IMAGE}}" = "true"
     cmds:
       - task: build-if-local
-        vars: { USE_GHCR_IMAGE: "{{.USE_GHCR_IMAGE}}" }
+        vars: {USE_GHCR_IMAGE: "{{.USE_GHCR_IMAGE}}"}
 
   wait:
     internal: true

--- a/.taskfiles/quality.yml
+++ b/.taskfiles/quality.yml
@@ -25,4 +25,3 @@ tasks:
     desc: Check for CRAP regressions against baseline for all modules
     cmds:
       - bash {{.ROOT_DIR}}/.taskfiles/scripts/go-module-runner.sh crapload-check
-


### PR DESCRIPTION
## Summary

Fixes all yamllint violations flagged by MegaLinter CI. Resolves 16 errors and 3 warnings across 5 files.

## Changes

### Brace spacing in Taskfiles (16 errors)

Removed extra spaces inside braces in Taskfile `vars:` and `for:` shorthand to comply with yamllint's default `braces` rule.

- `.taskfiles/integration.yml` — 6 locations
- `.taskfiles/infra.yml` — 2 locations

Example: `{ PROFILE: "{{.PROFILE}}" }` → `{PROFILE: "{{.PROFILE}}"}`

### Trailing blank line (1 warning)

- `.taskfiles/quality.yml` — removed trailing blank line at end of file

### Comment indentation (2 warnings)

- `.github/workflows/ci_checks.yml` — moved comment block above `permissions:` to align with surrounding content
- `.github/workflows/ci_publish_ghcr.yml` — dedented comment to `jobs` level to match next sibling

## Notes

The `.yamllint.yml` config is synced from [org-infra](https://github.com/complytime/org-infra) via the Sync Organization Repositories workflow, so all fixes are applied to the source files rather than modifying the lint configuration.

## Verification

`yamllint .` returns zero errors and zero warnings after these changes.

Closes #108

Signed-off-by: Yvonne Devlin <ydevlin@redhat.com>
Assisted-by: OpenCode (claude-opus-4-6)