### PR TITLE
docs: fix post-merge cleanup from TruthBeam removal

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -2,4 +2,3 @@
 *
 !beacon-distro/manifest.yaml
 !beacon-distro/config.yaml
-!truthbeam/

--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ Production deployments should use a dedicated collector configuration with `disa
 
 ### 4. Authentication
 
-Beacon bundles an OTel Collector auth extension (`oidcauthextension`) but does **not** enable it by default — the shipped configs prioritize development simplicity. A `bearertokenauthextension` is also available in the extension registry for outbound authentication.
+Beacon bundles two OTel Collector auth extensions but does **not** enable them by default — the shipped configs prioritize development simplicity.
 
-| Extension           | Direction | Purpose                                               |
-|---------------------|-----------|-------------------------------------------------------|
-| `oidcauthextension` | Inbound   | Validates OIDC (JWT) tokens on incoming OTLP requests |
+| Extension                  | Direction | Purpose                                                  |
+|----------------------------|-----------|----------------------------------------------------------|
+| `oidcauthextension`        | Inbound   | Validates OIDC (JWT) tokens on incoming OTLP requests    |
+| `bearertokenauthextension` | Outbound  | Attaches a static bearer token to outgoing HTTP requests |
 
 #### Configuring OIDC on OTLP Receivers
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -198,8 +198,8 @@ You've mixed stable/experimental versions from different releases. Reset to the 
 
 ```bash
 cd proofwatch
-# Downgrade to current pinned versions
-go get go.opentelemetry.io/otel/log@v1.57.0
+# Downgrade to current pinned versions (example — use the versions from Step 3)
+go get go.opentelemetry.io/collector/pdata@v1.61.0
 go mod tidy
 cd ..
 task version:sync


### PR DESCRIPTION
Address review feedback from #328 and minor documentation improvements
identified during post-merge review.

### Changes

- **docs/DEVELOPMENT.md**: Fix invalid package version in troubleshooting
  example — `go.opentelemetry.io/otel/log` is in the `v0.x` series, so
  `@v1.57.0` does not exist. Replace with
  `go.opentelemetry.io/collector/pdata@v1.61.0` which matches proofwatch's
  actual pinned dependency
  ([review comment](https://github.com/complytime/complytime-collector-components/pull/328#discussion_r3501722787))
- **.containerignore**: Remove stale `!truthbeam/` allowlist entry — the
  Containerfile no longer COPYs truthbeam sources
  ([review comment](https://github.com/complytime/complytime-collector-components/pull/328#issuecomment-4856626553))
- **README.md**: Restore `bearertokenauthextension` row in the auth
  extension table — the extension is still bundled in the distro manifest
  (`beacon-distro/manifest.yaml`) and available for outbound authentication

Assisted-by: OpenCode (claude-opus-4-6)
Signed-off-by: Marcus Burghardt <maburgha@redhat.com>
