### PR TITLE
chore: remove stale truthbeam references

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -87,7 +87,7 @@ resource "grafana_dashboard" "compliance_evidence" {
             uid  = data.grafana_data_source.loki.uid
           }
           editorMode = "code"
-          # Count enriched evidence logs (have policy_evaluation_result from truthbeam - signaltometrics logs don't have this)
+          # Count evidence logs that have a policy_evaluation_result attribute
           expr       = "sum(count_over_time({service_name=~\".+\"} | json | policy_evaluation_result=~\".+\" [$__range]))"
           queryType  = "range"
           refId      = "A"
@@ -144,7 +144,7 @@ resource "grafana_dashboard" "compliance_evidence" {
             uid  = data.grafana_data_source.loki.uid
           }
           editorMode   = "code"
-          # Query enriched evidence logs (have policy_evaluation_result from truthbeam - signaltometrics logs don't have this)
+          # Query evidence logs that have a policy_evaluation_result attribute
           expr         = "sum by (policy_evaluation_result) (count_over_time({service_name=~\".+\"} | json | policy_evaluation_result=~\".+\" [$__interval]))"
           legendFormat = "{{policy_evaluation_result}}"
           queryType    = "range"
@@ -279,7 +279,7 @@ resource "grafana_dashboard" "compliance_evidence" {
             uid  = data.grafana_data_source.loki.uid
           }
           editorMode   = "code"
-          # Query enriched evidence logs (have policy_engine_name from truthbeam - signaltometrics logs don't have policy_evaluation_result)
+          # Query evidence logs by policy_engine_name (filtered to those with policy_evaluation_result)
           expr         = "sum by (policy_engine_name) (count_over_time({service_name=~\".+\"} | json | policy_engine_name=~\".+\" and policy_evaluation_result=~\".+\" [$__range]))"
           legendFormat = "{{policy_engine_name}}"
           queryType    = "range"
@@ -337,7 +337,7 @@ resource "grafana_dashboard" "compliance_evidence" {
             uid  = data.grafana_data_source.loki.uid
           }
           editorMode   = "code"
-          # Query enriched evidence logs (have policy_rule_id from truthbeam - signaltometrics logs don't have policy_evaluation_result)
+          # Query evidence logs by policy_rule_id (filtered to those with policy_evaluation_result)
           expr         = "sum by (policy_rule_id) (count_over_time({service_name=~\".+\"} | json | policy_rule_id=~\".+\" and policy_evaluation_result=~\".+\" [$__range]))"
           legendFormat = "{{policy_rule_id}}"
           queryType    = "range"
@@ -394,7 +394,7 @@ resource "grafana_dashboard" "compliance_evidence" {
             uid  = data.grafana_data_source.loki.uid
           }
           editorMode = "code"
-          # Query enriched logs: real-time evidence rate per control (uses compliance_control_id from truthbeam when available, otherwise policy_rule_id)
+          # Query real-time evidence rate per control (groups by compliance_control_id and policy_rule_id)
           expr         = "sum by (compliance_control_id, policy_rule_id) (rate({service_name=~\".+\"} | json | policy_evaluation_result=~\".+\" and policy_rule_id=~\".+\" [$__interval]))"
           legendFormat = "{{compliance_control_id}} ({{policy_rule_id}})"
           queryType    = "range"

--- a/openspec/specs/gemara-evidence-attributes/spec.md
+++ b/openspec/specs/gemara-evidence-attributes/spec.md
@@ -17,7 +17,7 @@ The `GemaraEvidence.Attributes()` method SHALL emit the `policy.rule.id` OTel at
 All Gemara type references SHALL use the official `gemaraproj/go-gemara` v0.3.0 SDK types: `Actor` (not `Author`), `EntryMapping` (not `Mapping`), `Plan` (not `Procedure`), and `Metadata`/`AssessmentLog` from the top-level package (not `layer4` sub-package).
 
 #### Scenario: Import path correctness
-- **WHEN** any Go source file in `proofwatch` or `truthbeam` imports Gemara types
+- **WHEN** any Go source file in `proofwatch` imports Gemara types
 - **THEN** the import path SHALL be `github.com/gemaraproj/go-gemara` and SHALL NOT reference `github.com/ossf/gemara/layer4`
 
 ### Requirement: policy.rule.id requirement level alignment

--- a/proofwatch/.gaze/baseline.json
+++ b/proofwatch/.gaze/baseline.json
@@ -30,9 +30,9 @@
     },
     {
       "package": "main",
-      "function": "simulateTruthBeamEnrichment",
+      "function": "addComplianceAttributes",
       "file": "cmd/validate-logs/main.go",
-      "line": 113,
+      "line": 111,
       "complexity": 8,
       "line_coverage": 0,
       "crap": 72,
@@ -42,7 +42,7 @@
       "package": "main",
       "function": "convertToWeaverFormat",
       "file": "cmd/validate-logs/main.go",
-      "line": 178,
+      "line": 172,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -52,7 +52,7 @@
       "package": "main",
       "function": "valueToString",
       "file": "cmd/validate-logs/main.go",
-      "line": 211,
+      "line": 205,
       "complexity": 8,
       "line_coverage": 0,
       "crap": 72,
@@ -62,7 +62,7 @@
       "package": "main",
       "function": "stringPtr",
       "file": "cmd/validate-logs/main.go",
-      "line": 236,
+      "line": 230,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -71,7 +71,7 @@
       "package": "main",
       "function": "main",
       "file": "cmd/validate-logs/main.go",
-      "line": 240,
+      "line": 234,
       "complexity": 18,
       "line_coverage": 0,
       "crap": 342,
@@ -84,10 +84,7 @@
       "line": 19,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 0,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
+      "crap": 2
     },
     {
       "package": "proofwatch",
@@ -96,10 +93,7 @@
       "line": 29,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 0,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
+      "crap": 2
     },
     {
       "package": "proofwatch",
@@ -108,10 +102,7 @@
       "line": 39,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 0,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe"
+      "crap": 2
     },
     {
       "package": "proofwatch",
@@ -147,10 +138,7 @@
       "line": 19,
       "complexity": 3,
       "line_coverage": 77.77777777777777,
-      "crap": 3.0987654320987654,
-      "contract_coverage": 0,
-      "gaze_crap": 12,
-      "quadrant": "Q1_Safe"
+      "crap": 3.0987654320987654
     },
     {
       "package": "metrics",
@@ -159,11 +147,7 @@
       "line": 45,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe",
-      "contract_coverage_reason": "no_effects_detected"
+      "crap": 1
     },
     {
       "package": "metrics",
@@ -172,17 +156,13 @@
       "line": 49,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 0,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe",
-      "contract_coverage_reason": "no_effects_detected"
+      "crap": 1
     },
     {
       "package": "proofwatch",
       "function": "(OCSFEvidence).Timestamp",
       "file": "ocsf.go",
-      "line": 28,
+      "line": 27,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -191,7 +171,7 @@
       "package": "proofwatch",
       "function": "(OCSFEvidence).ToJSON",
       "file": "ocsf.go",
-      "line": 32,
+      "line": 31,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -200,7 +180,7 @@
       "package": "proofwatch",
       "function": "(OCSFEvidence).Attributes",
       "file": "ocsf.go",
-      "line": 36,
+      "line": 35,
       "complexity": 6,
       "line_coverage": 87.5,
       "crap": 6.0703125
@@ -209,7 +189,7 @@
       "package": "proofwatch",
       "function": "stringVal",
       "file": "ocsf.go",
-      "line": 68,
+      "line": 67,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -218,7 +198,7 @@
       "package": "proofwatch",
       "function": "mapEvaluationStatus",
       "file": "ocsf.go",
-      "line": 77,
+      "line": 76,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -227,7 +207,7 @@
       "package": "proofwatch",
       "function": "mapEnforcementAction",
       "file": "ocsf.go",
-      "line": 92,
+      "line": 91,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -236,7 +216,7 @@
       "package": "proofwatch",
       "function": "mapEnforcementStatus",
       "file": "ocsf.go",
-      "line": 110,
+      "line": 109,
       "complexity": 16,
       "line_coverage": 100,
       "crap": 16,
@@ -246,7 +226,7 @@
       "package": "proofwatch",
       "function": "validateEvidenceFields",
       "file": "ocsf.go",
-      "line": 135,
+      "line": 134,
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7
@@ -258,10 +238,7 @@
       "line": 30,
       "complexity": 3,
       "line_coverage": 87.5,
-      "crap": 3.017578125,
-      "contract_coverage": 0,
-      "gaze_crap": 12,
-      "quadrant": "Q1_Safe"
+      "crap": 3.017578125
     },
     {
       "package": "proofwatch",
@@ -279,11 +256,7 @@
       "line": 60,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 0,
-      "gaze_crap": 6,
-      "quadrant": "Q1_Safe",
-      "contract_coverage_reason": "no_effects_detected"
+      "crap": 2
     },
     {
       "package": "proofwatch",
@@ -292,10 +265,7 @@
       "line": 91,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "contract_coverage": 100,
-      "gaze_crap": 2,
-      "quadrant": "Q1_Safe"
+      "crap": 2
     },
     {
       "package": "proofwatch",
@@ -304,10 +274,7 @@
       "line": 100,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "contract_coverage": 100,
-      "gaze_crap": 1,
-      "quadrant": "Q1_Safe"
+      "crap": 1
     }
   ],
   "summary": {
@@ -317,13 +284,6 @@
     "avg_crap": 20.406221868569958,
     "crapload": 6,
     "crap_threshold": 15,
-    "gaze_crapload": 0,
-    "gaze_crap_threshold": 15,
-    "avg_gaze_crap": 5.5,
-    "avg_contract_coverage": 20,
-    "quadrant_counts": {
-      "Q1_Safe": 10
-    },
     "fix_strategy_counts": {
       "add_tests": 4,
       "decompose": 1,
@@ -334,7 +294,7 @@
         "package": "main",
         "function": "main",
         "file": "cmd/validate-logs/main.go",
-        "line": 240,
+        "line": 234,
         "complexity": 18,
         "line_coverage": 0,
         "crap": 342,
@@ -342,9 +302,9 @@
       },
       {
         "package": "main",
-        "function": "simulateTruthBeamEnrichment",
+        "function": "addComplianceAttributes",
         "file": "cmd/validate-logs/main.go",
-        "line": 113,
+        "line": 111,
         "complexity": 8,
         "line_coverage": 0,
         "crap": 72,
@@ -354,7 +314,7 @@
         "package": "main",
         "function": "valueToString",
         "file": "cmd/validate-logs/main.go",
-        "line": 211,
+        "line": 205,
         "complexity": 8,
         "line_coverage": 0,
         "crap": 72,
@@ -374,81 +334,19 @@
         "package": "main",
         "function": "convertToWeaverFormat",
         "file": "cmd/validate-logs/main.go",
-        "line": 178,
+        "line": 172,
         "complexity": 4,
         "line_coverage": 0,
         "crap": 20,
         "fix_strategy": "add_tests"
       }
     ],
-    "worst_gaze_crap": [
-      {
-        "package": "metrics",
-        "function": "NewEvidenceObserver",
-        "file": "internal/metrics/observer.go",
-        "line": 19,
-        "complexity": 3,
-        "line_coverage": 77.77777777777777,
-        "crap": 3.0987654320987654,
-        "contract_coverage": 0,
-        "gaze_crap": 12,
-        "quadrant": "Q1_Safe"
-      },
-      {
-        "package": "proofwatch",
-        "function": "NewProofWatch",
-        "file": "proofwatch.go",
-        "line": 30,
-        "complexity": 3,
-        "line_coverage": 87.5,
-        "crap": 3.017578125,
-        "contract_coverage": 0,
-        "gaze_crap": 12,
-        "quadrant": "Q1_Safe"
-      },
-      {
-        "package": "proofwatch",
-        "function": "WithMeterProvider",
-        "file": "config.go",
-        "line": 19,
-        "complexity": 2,
-        "line_coverage": 100,
-        "crap": 2,
-        "contract_coverage": 0,
-        "gaze_crap": 6,
-        "quadrant": "Q1_Safe"
-      },
-      {
-        "package": "proofwatch",
-        "function": "WithLoggerProvider",
-        "file": "config.go",
-        "line": 29,
-        "complexity": 2,
-        "line_coverage": 100,
-        "crap": 2,
-        "contract_coverage": 0,
-        "gaze_crap": 6,
-        "quadrant": "Q1_Safe"
-      },
-      {
-        "package": "proofwatch",
-        "function": "WithTracerProvider",
-        "file": "config.go",
-        "line": 39,
-        "complexity": 2,
-        "line_coverage": 100,
-        "crap": 2,
-        "contract_coverage": 0,
-        "gaze_crap": 6,
-        "quadrant": "Q1_Safe"
-      }
-    ],
     "recommended_actions": [
       {
-        "function": "simulateTruthBeamEnrichment",
+        "function": "addComplianceAttributes",
         "package": "main",
         "file": "cmd/validate-logs/main.go",
-        "line": 113,
+        "line": 111,
         "fix_strategy": "add_tests",
         "crap": 72,
         "complexity": 8
@@ -457,7 +355,7 @@
         "function": "valueToString",
         "package": "main",
         "file": "cmd/validate-logs/main.go",
-        "line": 211,
+        "line": 205,
         "fix_strategy": "add_tests",
         "crap": 72,
         "complexity": 8
@@ -475,7 +373,7 @@
         "function": "convertToWeaverFormat",
         "package": "main",
         "file": "cmd/validate-logs/main.go",
-        "line": 178,
+        "line": 172,
         "fix_strategy": "add_tests",
         "crap": 20,
         "complexity": 4
@@ -484,7 +382,7 @@
         "function": "main",
         "package": "main",
         "file": "cmd/validate-logs/main.go",
-        "line": 240,
+        "line": 234,
         "fix_strategy": "decompose_and_test",
         "crap": 342,
         "complexity": 18
@@ -493,7 +391,7 @@
         "function": "mapEnforcementStatus",
         "package": "proofwatch",
         "file": "ocsf.go",
-        "line": 110,
+        "line": 109,
         "fix_strategy": "decompose",
         "crap": 16,
         "complexity": 16


### PR DESCRIPTION
## Summary

Remove dangling truthbeam references that were missed during the TruthBeam removal in PR #328.

## Changes

| Issue | File | Change |
|-------|------|--------|
| #368 | `openspec/specs/gemara-evidence-attributes/spec.md` | Remove `or \`truthbeam\`` from import path correctness scenario |
| #365 | `deploy/terraform/main.tf` | Rewrite 5 stale comments to describe current behavior without truthbeam |
| #367 | `proofwatch/.gaze/baseline.json` | Regenerate baseline — removes 3 references to deleted `simulateTruthBeamEnrichment` function |

## Notes
- No behavioral changes — all edits are comments, specs, and a regenerated baseline.
- Tests pass: `go test -mod=mod ./...` in `proofwatch/`.

Closes #362
Closes #365
Closes #367
Closes #368