### PR TITLE
chore(deps): bump Go from 1.26.4 to 1.26.5

### DIFF
--- a/.github/workflows/ci_local.yml
+++ b/.github/workflows/ci_local.yml
@@ -15,7 +15,7 @@ permissions:
   security-events: none
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
   GOLANGCI_LINT_VERSION: v2.12
   WEAVER_VERSION: v0.21.2
 

--- a/.github/workflows/ci_sonarcloud.yml
+++ b/.github/workflows/ci_sonarcloud.yml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: none
 
 env:
-  GO_VERSION: 1.26.4
+  GO_VERSION: 1.26.5
 
 jobs:
   generate-coverage:

--- a/beacon-distro/Containerfile.collector
+++ b/beacon-distro/Containerfile.collector
@@ -3,7 +3,7 @@
 # Stage 2: Create minimal runtime image with UBI Minimal base
 
 # Stage 1: Build the OpenTelemetry Collector
-FROM golang:1.26.4@sha256:82c8738642b733f7d2f44b057375ec90d17c294ff6689aedc628afa9c2b2ceff AS build-stage
+FROM golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS build-stage
 WORKDIR /build
 
 # Build the collector using the OpenTelemetry collector builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/complytime/complybeacon
 
-go 1.26.4
+go 1.26.5
 
 tool github.com/unbound-force/gaze/cmd/gaze
 

--- a/proofwatch/go.mod
+++ b/proofwatch/go.mod
@@ -1,6 +1,6 @@
 module github.com/complytime/complybeacon/proofwatch
 
-go 1.26.4
+go 1.26.5
 
 tool github.com/unbound-force/gaze/cmd/gaze
 

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/complytime/complybeacon/tests/integration
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/onsi/ginkgo/v2 v2.32.0


### PR DESCRIPTION
Update the Go version across all version-pinned locations in the repository, replacing Renovate PR #392 which only updated `go.mod` files and left the source of truth (`go.work`), CI workflows, and Containerfile on 1.26.4 — causing 5 CI failures from version drift.

### Changes

| File | What changed |
|------|--------------|
| `go.work` | `go 1.26.4` → `go 1.26.5` (source of truth) |
| `go.mod` | Module directive bump |
| `proofwatch/go.mod` | Module directive bump |
| `tests/integration/go.mod` | Module directive bump |
| `.github/workflows/ci_local.yml` | `GO_VERSION` env var |
| `.github/workflows/ci_sonarcloud.yml` | `GO_VERSION` env var |
| `beacon-distro/Containerfile.collector` | Base image tag + pinned digest |

### Verification

`task version:check` passes — all Go and OTel versions are aligned.

### Context

Closes #392. Renovate's `go` manager only targets `go.mod` files, but this repository enforces version consistency across `go.work`, CI workflow env vars, and Containerfile base images via `task version:check`. This PR performs the complete update that Renovate could not.