### PR TITLE
chore(deps): bump go.opentelemetry.io/otel/log from 0.20.0 to 0.21.0

### DIFF
--- a/proofwatch/go.mod
+++ b/proofwatch/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/telophasehq/go-ocsf v0.2.1
 	go.opentelemetry.io/collector/pdata v1.63.0
 	go.opentelemetry.io/otel v1.45.0
-	go.opentelemetry.io/otel/log v0.20.0
+	go.opentelemetry.io/otel/log v0.21.0
 	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
 	go.opentelemetry.io/otel/sdk/metric v1.45.0

--- a/proofwatch/go.sum
+++ b/proofwatch/go.sum
@@ -134,8 +134,8 @@ go.opentelemetry.io/collector/pdata v1.63.0 h1:fY2xSG2MnyoBwA4GUhzoogGZMuNS0qHpC
 go.opentelemetry.io/collector/pdata v1.63.0/go.mod h1:jzozYYhQEkTQ/CCbCBNC+hYUeju9S2J8HIqIDHdxZWk=
 go.opentelemetry.io/otel v1.45.0 h1:pdrWmLHofpubmArBv1LgFSv1Z0Ie/ppdZzu+kUN5EeU=
 go.opentelemetry.io/otel v1.45.0/go.mod h1:XZxIqPapzEYnhNSScF5DIqXhm/rYi0FzCe2XddAwZfQ=
-go.opentelemetry.io/otel/log v0.20.0 h1:/5i0vuHxCLWUfChWG41K9wkM0jafruPw9NU1/RCJirs=
-go.opentelemetry.io/otel/log v0.20.0/go.mod h1:wOcMcjsZpG8x7Bak7IhSi/lg8wscV2C1VdrKCLPlt0E=
+go.opentelemetry.io/otel/log v0.21.0 h1:SLsVDGmtyBrdw8/a2Z0bOIxou/+bN4z56GebH7T0LvA=
+go.opentelemetry.io/otel/log v0.21.0/go.mod h1:iReetQrZL9Wyg84cCkOoCmqDHS5RCFfyxC7J+r8fn8g=
 go.opentelemetry.io/otel/metric v1.45.0 h1:7Eg1uH7CJ5cXv9is6tnBe1FI6rj1nwUdbFypRm3br/M=
 go.opentelemetry.io/otel/metric v1.45.0/go.mod h1:HAPbm1nd3p1PmFH7v2dR+6BjXxw+Lq4a2+pndMAm08s=
 go.opentelemetry.io/otel/metric/x v0.67.0 h1:PcicCNZFkZ4bXfSooXdo3WN7RBOVOtjVdo1wD358Uns=

--- a/proofwatch/proofwatch.go
+++ b/proofwatch/proofwatch.go
@@ -75,8 +75,8 @@ func (w *ProofWatch) LogWithSeverity(ctx context.Context, evidence Evidence, sev
 	record.SetObservedTimestamp(time.Now())
 	// Set event time
 	record.SetTimestamp(evidence.Timestamp())
-	record.AddAttributes(ToLogKeyValues(attrs)...)
-	record.SetBody(olog.StringValue(string(jsonData))) // Retains the original body for flexibility.
+	record.AddAttributes(attrs...)
+	record.SetBody(attribute.StringValue(string(jsonData))) // Retains the original body for flexibility.
 
 	span.AddEvent("evidence.logged", trace.WithAttributes(attrs...), trace.WithTimestamp(time.Now()))
 
@@ -85,15 +85,6 @@ func (w *ProofWatch) LogWithSeverity(ctx context.Context, evidence Evidence, sev
 	w.observer.Processed(ctx, attrs...)
 
 	return nil
-}
-
-// ToLogKeyValues converts slice of attribute.KeyValue to log.KeyValue
-func ToLogKeyValues(attrs []attribute.KeyValue) []olog.KeyValue {
-	logAttrs := make([]olog.KeyValue, len(attrs))
-	for i, attr := range attrs {
-		logAttrs[i] = olog.KeyValueFromAttribute(attr)
-	}
-	return logAttrs
 }
 
 // Version is the current release version of Proofwatch

--- a/proofwatch/proofwatch_test.go
+++ b/proofwatch/proofwatch_test.go
@@ -201,21 +201,6 @@ func TestVersion(t *testing.T) {
 	assert.Equal(t, "0.1.0", version)
 }
 
-func TestToLogKeyValues(t *testing.T) {
-	attrs := []attribute.KeyValue{
-		attribute.String("key1", "value1"),
-		attribute.Int("key2", 42),
-		attribute.Bool("key3", true),
-	}
-
-	logAttrs := ToLogKeyValues(attrs)
-
-	assert.Equal(t, len(attrs), len(logAttrs))
-	for i, logAttr := range logAttrs {
-		assert.Equal(t, string(attrs[i].Key), logAttr.Key)
-	}
-}
-
 // createTestEvidence is defined in ocsf_test.go and shared across test files
 // createTestGemaraEvidence is defined in gemara_test.go
 // invalidEvidence is a test implementation that fails JSON marshaling


### PR DESCRIPTION
## Summary

Bump `go.opentelemetry.io/otel/log` from v0.20.0 to v0.21.0 and adapt proofwatch to the breaking API changes introduced in [opentelemetry-go#8490](https://github.com/open-telemetry/opentelemetry-go/issues/8490).

Closes #412 (supersedes Dependabot PR which could not handle the breaking changes).

## Breaking change in otel/log v0.21.0

The `log.Kind`, `log.Value`, `log.KeyValue` types, their constructors, and attribute conversion helpers were **removed** from `go.opentelemetry.io/otel/log`. The log API now uses `attribute.Value` and `attribute.KeyValue` directly, unifying the attribute model across traces, metrics, and logs.

## Changes

### proofwatch/proofwatch.go
- **`Record.SetBody`**: replaced `olog.StringValue(...)` with `attribute.StringValue(...)` (method now accepts `attribute.Value`)
- **`Record.AddAttributes`**: pass `attrs` (`[]attribute.KeyValue`) directly instead of converting through `ToLogKeyValues` (method now accepts `...attribute.KeyValue`)
- **Removed `ToLogKeyValues`**: this helper converted `[]attribute.KeyValue` → `[]olog.KeyValue`, which is now an identity operation and no longer needed

### proofwatch/proofwatch_test.go
- Removed `TestToLogKeyValues` (tests a function that no longer exists)

### proofwatch/go.mod
| Dependency | Before | After |
|---|---|---|
| `go.opentelemetry.io/otel/log` | v0.20.0 | **v0.21.0** |
| `go.opentelemetry.io/otel` | v1.44.0 | v1.45.0 |
| `go.opentelemetry.io/otel/metric` | v1.44.0 | v1.45.0 |
| `go.opentelemetry.io/otel/trace` | v1.44.0 | v1.45.0 |
| `github.com/go-logr/logr` | v1.4.3 | v1.4.4 |

## Verification

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all tests green)
- [x] `golangci-lint run ./...` passes (0 issues)